### PR TITLE
configure a qa horizon instance

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -81,6 +81,16 @@ return [
             ],
         ],
 
+        'qa' => [
+            'supervisor-1' => [
+                'connection' => 'redis',
+                'queue' => ['importer'],
+                'balance' => 'simple',
+                'processes' => 3,
+                'tries' => 3,
+            ],
+        ],
+
         'local' => [
             'supervisor-1' => [
                 'connection' => 'redis',


### PR DESCRIPTION
The PR configures Horizon for a `qa` environment (set by the `APP_ENV` variable) 