### PR TITLE
Check for user before authorizing Horizon

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,7 +18,11 @@ class AppServiceProvider extends ServiceProvider
 
         // Horizon Dashboard Authentication.
         \Horizon::auth(function ($request) {
-            return auth()->user()->role === 'admin';
+            if (auth()->user()) {
+                return auth()->user()->role === 'admin';
+            }
+
+            return false;
         });
     }
 


### PR DESCRIPTION
We check if a user is authorized to see the Horizon dashboard using the `auth()->user()` helper but we have to check if `auth()->user()` exists before using it. 