### PR TITLE
If the referral code is empty, don't skip the record

### DIFF
--- a/app/Jobs/ImportTurboVotePosts.php
+++ b/app/Jobs/ImportTurboVotePosts.php
@@ -216,7 +216,6 @@ class ImportTurboVotePosts implements ShouldQueue
             ];
         }
 
-
         return $values;
     }
 


### PR DESCRIPTION
#### What's this PR do?
This updates the chompy logic that imports records from a TurboVote export. 

Before, we would loop through each record and skip any records in the CSV that did not have a `referral-code`. 

After some tests, we decided that we actually do _not_ want to skip these records. 

If the referral code is empty, we continue to process the record, use a standard set of default values, and then create or get the user from northstar using the `email` or `phone` provided. 

The core of the work is [here ](https://github.com/DoSomething/chompy/compare/count-empty-referralcodes?diff=split&expand=1&name=count-empty-referralcodes#diff-ed45aaf47afdecacbc92e2d0393dc00bL183) and that is just the method that decides how to parse the referral code or if it doesn't exist, set the default referral code values. 

#### How should this be reviewed?
👀 

This might be hard to view because I had indetation that needed to change. I would look at this in split view for easier reading. 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/157411893) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
