### PR TITLE
Validate referral code

### DIFF
--- a/app/Jobs/ImportTurboVotePosts.php
+++ b/app/Jobs/ImportTurboVotePosts.php
@@ -207,7 +207,7 @@ class ImportTurboVotePosts implements ShouldQueue
             }
         }
 
-        // If the referral code is not present or we didn't get the right fields, use these default values.
+        // Make sure we have all the values we need, otherwise, use the defaults.
         if (empty($values) || !array_has($values, ['northstar_id', 'campaign_id', 'campaign_run_id'])) {
             $values = [
                 'northstar_id' => null, // set the user to null so we force account creation when the code is not present.

--- a/app/Jobs/ImportTurboVotePosts.php
+++ b/app/Jobs/ImportTurboVotePosts.php
@@ -205,8 +205,10 @@ class ImportTurboVotePosts implements ShouldQueue
                     $values['source_details'] = $value[1];
                 }
             }
-        } else {
-            // If the referral code is not present, use these default values.
+        }
+
+        // If the referral code is not present or we didn't get the right fields, use these default values.
+        if (empty($values) || !array_has($values, ['northstar_id', 'campaign_id', 'campaign_run_id'])) {
             $values = [
                 'northstar_id' => null, // set the user to null so we force account creation when the code is not present.
                 'campaign_id' => 8017,


### PR DESCRIPTION
### What does this PR do

We use the `referral-code` column in the turbovote csv to associate user/campaign data with the voter-reg post. 

Mostly, the `referral-code` looks like: `user:5a854f70a0bfad749a0449f1,campaignID:8017,campaignRunID:8022,source:email,source_details:newsletter_266` 
This is good. 

But sometimes the `referral-code` looks like: 
`11_facts,utm_source:dosomething,utm_medium:11_facts,utm_campaign:8017,utm_content:bullying`

Not as good. 

So this updates the logic to make sure we have what we need, otherwise use the defaults. 
