### PR TITLE
Set ROGUE_URL variable from command

### DIFF
--- a/app/Console/Commands/SetupCommand.php
+++ b/app/Console/Commands/SetupCommand.php
@@ -57,7 +57,7 @@ class SetupCommand extends Command
                 'https://rogue-thor.dosomething.org'
             ];
 
-            $this->chooseEnvironmentVariable('Rogue_URL', 'Choose a Rogue environment', $environments);
+            $this->chooseEnvironmentVariable('ROGUE_URL', 'Choose a Rogue environment', $environments);
 
         });
 


### PR DESCRIPTION
Noticed that the setup command wasn't changing my `ROGUE_URL` environment variable, turns out it's case sensitive!