### PR TITLE
Import Rock The Vote posts/signups to Rogue

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -7,6 +7,7 @@ use League\Csv\Reader;
 use Illuminate\Http\Request;
 use Chompy\Jobs\ImportTurboVotePosts;
 use Illuminate\Support\Facades\Storage;
+use Chompy\Jobs\ImportRockTheVotePosts;
 
 class ImportController extends Controller
 {
@@ -56,6 +57,11 @@ class ImportController extends Controller
         if ($request->input('import-type') === 'turbovote') {
             info("turbo vote import happening");
             ImportTurboVotePosts::dispatch($path)->delay(now()->addSeconds(3));
+        }
+
+        if ($request->input('import-type') === 'rock-the-vote') {
+            info('rock the vote import happening');
+            ImportRockTheVotePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
         return redirect()->route('import.show')->with('status', 'Your CSV was added to the queue to be processed.');

--- a/app/Jobs/ImportRockTheVotePosts.php
+++ b/app/Jobs/ImportRockTheVotePosts.php
@@ -185,29 +185,34 @@ class ImportRockTheVotePosts implements ShouldQueue
                     $value = explode('=', $value);
                 }
 
-                // Grab northstar id
-                if (strtolower($value[0]) === 'user') {
-                    $values['northstar_id'] = $value[1];
-                }
+                // Add northstar_id, campaign id and run, source, and source details into $values
+                switch (strtolower($value[0])) {
+                    case 'user':
+                        $values['northstar_id'] = $value[1];
+                        break;
 
-                // Grab the Campaign Id.
-                if (strtolower($value[0]) === 'campaignid' || strtolower($value[0]) === 'campaign') {
-                    $values['campaign_id'] = $value[1];
-                }
+                    case 'campaignid':
+                        $values['campaign_id'] = $value[1];
+                        break;
 
-                // Grab the Campaign Run Id.
-                if (strtolower($value[0]) === 'campaignrunid') {
-                    $values['campaign_run_id'] = $value[1];
-                }
+                    case 'campaign':
+                        $values['campaign_id'] = $value[1];
+                        break;
 
-                // Grab the source
-                if (strtolower($value[0]) === 'source') {
-                    $values['source'] = $value[1];
-                }
+                    case 'campaignrunid':
+                        $values['campaign_run_id'] = $value[1];
+                        break;
 
-                // Grab any source details
-                if (strtolower($value[0]) === 'source_details') {
-                    $values['source_details'] = $value[1];
+                    case 'source':
+                        $values['source'] = $value[1];
+                        break;
+
+                    case 'source_details':
+                        $values['source_details'] = $value[1];
+                        break;
+
+                    default:
+                        break;
                 }
 
                 // Is this a referral?

--- a/app/Jobs/ImportRockTheVotePosts.php
+++ b/app/Jobs/ImportRockTheVotePosts.php
@@ -1,0 +1,414 @@
+<?php
+
+namespace Chompy\Jobs;
+
+use Chompy\Stat;
+use Carbon\Carbon;
+use League\Csv\Reader;
+use Chompy\Services\Rogue;
+use Chompy\Events\LogProgress;
+use Illuminate\Bus\Queueable;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class ImportRockTheVotePosts implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    /**
+     * The path to the stored csv.
+     *
+     * @var string
+     */
+    protected $filepath;
+
+    /**
+     * The path to the stored csv.
+     *
+     * @var array
+     */
+    protected $stats;
+
+    protected $totalRecords;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($filepath)
+    {
+        $this->filepath = $filepath;
+
+        $this->stats = $this->statsInit();
+    }
+
+    /**
+     * Get the tags that should be assigned to the job.
+     *
+     * @return array
+     */
+    public function tags()
+    {
+        return ['rock-the-vote'];
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        info('STARTING');
+
+        $records = $this->getCSVRecords($this->filepath);
+
+        foreach ($records as $offset => $record)
+        {
+            $shouldProcess = $this->scrubRecord($record);
+
+            if ($shouldProcess) {
+                info('progress_log: Processing: ' . $record['id']);
+
+                $referralCode = $record['Tracking Source'];
+                $referralCodeValues = $this->parseReferralCode($referralCode);
+
+                try {
+                    $user = $this->getOrCreateUser($record, $referralCodeValues);
+                } catch (\Exception $e) {
+                    info('There was an error with that user: ' . $record['id'], [
+                        'Error' => $e->getMessage(),
+                    ]);
+                }
+                
+                if ($user) {
+                    $post = $rogue->getPost([
+                        'campaign_id' => (int) $referralCodeValues['campaign_id'],
+                        'northstar_id' => $user->id,
+                        'type' => 'voter-reg',
+                    ]);
+
+                    if (! $post['data']) {
+                        $rtvCreatedAtMonth = strtolower(Carbon::parse($record['Started registration'])->format('F-Y'));
+                        // @TODO - is source_details a thing for RTV?
+                        $sourceDetails = isset($referralCodeValues['source_details']) ? $referralCodeValues['source_details'] : null;
+                        $postDetails = $this->extractDetails($record);
+
+                        $postData = [
+                            'campaign_id' => (int) $referralCodeValues['campaign_id'],
+                            'campaign_run_id' => (int) $referralCodeValues['campaign_run_id'],
+                            'northstar_id' => $user->id,
+                            'type' => 'voter-reg',
+                            'action' => $rtvCreatedAtMonth . '-rockthevote',
+                            'status' => $this->translateStatus($record['Status'], $record['Finish with State']),
+                            'source' => 'rock-the-vote',
+                            'source_details' => $sourceDetails,
+                            'details' => $postDetails,
+                        ];
+
+                        try {
+                            $post = $rogue->createPost($postData);
+
+                            if ($post['data']) {
+                                $this->stats['countPostCreated']++;
+                            }
+                        } catch (\Exception $e) {
+                            info('There was an error storing the post for: ' . $record['id'], [
+                                'Error' => $e->getMessage(),
+                            ]);
+                        }
+                    } else {
+                        $newStatus = $this->translateStatus($record['Status'], $record['Finish with State']);
+                        $statusShouldChange = $this->updateStatus($post['data'][0]['status'], $newStatus);
+
+                        if ($statusShouldChange) {
+                            try {
+                                $rogue->updatePost($post['data'][0]['id'], ['status' => $statusShouldChange]);
+                            } catch (\Exception $e) {
+                                info('There was an error updating the post for: ' . $record['id'], [
+                                    'Error' => $e->getMessage(),
+                                ]);
+                            }
+                        }
+                    }
+                }
+
+                $this->stats['countProcessed']++;
+            } else {
+                $this->stats['countScrubbed']++;
+            }
+
+            event(new LogProgress('', 'progress', ($offset / $this->totalRecords) * 100));
+        }
+
+        event(new LogProgress('Done!', 'general'));
+
+        Stat::create([
+            'filename' => $this->filepath,
+            'total_records' => $this->stats['totalRecords'],
+            'stats' => json_encode($this->stats),
+        ]);
+
+    }
+
+    /**
+     * Initiate the stat counters.
+     *
+     * @return array
+     */
+    private function statsInit()
+    {
+        return [
+            'totalRecords' => 0,
+            'countScrubbed' => 0,
+            'countProcessed' => 0,
+            'countPostCreated' => 0,
+            'countUserAccountsCreated' => 0,
+        ];
+    }
+
+    /**
+     * Parse the referral code field to grab individual values.
+     *
+     * @param  array $refferalCode
+     */
+    private function parseReferralCode($referralCode)
+    {
+        $values = [];
+
+        // Remove some nonsense that comes in front of the referral code sometimes
+        if (strrpos($referralCode, 'iframe?r=') !== false) {
+            $referralCode = str_replace('iframe?r=', null, $referralCode);  
+        }
+        if (strrpos($referralCode, 'iframe?') !== false) {
+            $referralCode = str_replace('iframe?', null, $referralCode);  
+        }
+
+        if (! empty($referralCode)) {
+            $referralCode = explode(',', $referralCode);
+
+            foreach ($referralCode as $value) {
+
+                $value = explode(':', $value);
+                // Grab northstar id
+                if (strtolower($value[0]) === 'user') {
+                    $values['northstar_id'] = $value[1];
+                }
+
+                // Grab the Campaign Id.
+                if (strtolower($value[0]) === 'campaignid' || strtolower($value[0]) === 'campaign') {
+                    $values['campaign_id'] = $value[1];
+                }
+
+                // Grab the Campaign Run Id.
+                if (strtolower($value[0]) === 'campaignrunid') {
+                    $values['campaign_run_id'] = $value[1];
+                }
+
+                // Grab the source
+                if (strtolower($value[0]) === 'source') {
+                    $values['source'] = $value[1];
+                }
+
+                // Grab any source details
+                if (strtolower($value[0]) === 'source_details') {
+                    $values['source_details'] = $value[1];
+                }
+            }
+        }
+
+        // Make sure we have all the values we need, otherwise, use the defaults.
+        // @TODO: QUESTION - Why don't we only set unset values as the defaults? The way we have it now we could be overwriting campaign_id if there is no northstar_id or vice versa
+        if (empty($values) || !array_has($values, ['northstar_id', 'campaign_id', 'campaign_run_id'])) {
+            $values = [
+                'northstar_id' => null, // set the user to null so we force account creation when the code is not present.
+                'campaign_id' => 8017,
+                'campaign_run_id' => 8022,
+                'source' => 'rock-the-vote',
+                'source_details' => null,
+            ];
+        }
+
+        return $values;
+    }
+
+    // @TODO: is this a thing for RTV??
+    /**
+     * Parse the record for extra details and return them as a JSON object.
+     *
+     * @param  array $record
+     * @param  array $extraData
+     */
+    private function extractDetails($record, $extraData = null)
+    {
+        $details = [];
+
+        $importantKeys = [
+            'hostname',
+            'referral-code',
+            'partner-comms-opt-in',
+            'created-at',
+            'updated-at',
+            'voter-registration-status',
+            'voter-registration-source',
+            'voter-registration-method',
+            'voting-method-preference',
+            'email subscribed',
+            'sms subscribed',
+        ];
+
+        foreach ($importantKeys as $key) {
+            $details[$key] = $record[$key];
+        }
+
+        if ($extraData) {
+            $details = array_merge($details, $extraData);
+        }
+
+        return json_encode($details);
+    }
+
+    /**
+     * Translate a status from Rock The Vote into a status that can be sent to Rogue.
+     *
+     * @param  string $rtvStatus
+     * @param  string $rtvFinishWithState
+     * @return string
+     */
+    private function translateStatus($rtvStatus, $rtvFinishWithState)
+    {
+        if($rtvStatus === 'complete') {
+            if ($rtvFinishWithState === "no") {
+                return 'register-form';
+            }
+            if ($rtvFinishWithState === "yes") {
+                return 'register-OVR';
+            }   
+        }
+
+        if (strpos($rtvStatus, 'step')) {
+            return 'uncertain';
+        }
+
+        if ($rtvStatus === 'rejected') {
+            return 'ineligible';
+        }
+
+        return '';
+    }
+
+    /*
+     * Determines if a status should be changed and what it should be changed to.
+     *
+     * @param string $currentStatus
+     * @param string $newStatus
+     * @return string|null
+     */
+    private function updateStatus($currentStatus, $newStatus)
+    {
+        $statusHierarchy = [
+            'uncertain',
+            'ineligible',
+            'confirmed',
+            'register-OVR',
+            'register-form',
+        ];
+
+        $indexOfCurrentStatus = array_search($currentStatus, $statusHierarchy);
+        $indexOfNewStatus = array_search($newStatus, $statusHierarchy);
+
+        return $indexOfCurrentStatus < $indexOfNewStatus ? $newStatus : null;
+    }
+
+    /*
+     * Determines if a record should be process to be stored or if it is not valid.
+     *
+     * @param array $record
+     * @return bool
+    */
+    private function scrubRecord($record)
+    {
+        $isNotValidEmail = strrpos($record['email'], 'thing.org') !== false || strrpos($record['email'] !== false, '@dosome') || strrpos($record['email'], 'rockthevote.com') !== false || strrpos($record['email'], 'test') !== false || strrpos($record['email'], '+') !== false;
+        $isNotValidHostname = strrpos($record['hostname'], 'testing') !== false;
+        $isNotValidLastName = strrpos($record['last-name'], 'Baloney') !== false;
+
+        return $isNotValidEmail || $isNotValidHostname || $isNotValidLastName ? false : true;
+    }
+
+    /**
+     * For a given record and referral code values, first check if we have a northstar ID, then grab the user using that.
+     * Otherwise, see if we can find the user with the given email (if it exists), if not check if we can find them with the given phone number (if it exists).
+     * If all else fails, create the user .
+     *
+     * @TODO - If we have a northstar id in the referral code, then we probably don't need to make a call to northstar for the full user object.
+     *
+     * @return array
+     */
+    private function getOrCreateUser($record, $values)
+    {
+        $user = null;
+
+        $userFieldsToLookFor = [
+            'id' => isset($values['northstar_id']) && !empty($values['northstar_id']) ? $values['northstar_id'] : null,
+            'email' => isset($record['email']) && !empty($record['email']) ? $record['email'] : null,
+            'mobile' => isset($record['phone']) && !empty($record['phone']) ? $record['phone'] : null,
+        ];
+
+        foreach ($userFieldsToLookFor as $field => $value)
+        {
+            if ($value) {
+                // info('getting user with the '.$field.' field', [$field => $value]);
+                $user = gateway('northstar')->asClient()->getUser($field, $value);
+            }
+
+            if ($user) {
+                break;
+            }
+        }
+
+        if (is_null($user)) {
+            $userData = [
+                'email' => $record['Email address'],
+                'mobile' => $record['Phone'],
+                'first_name' => $record['First name'],
+                'last_name' => $record['Last name'],
+                'addr_street1' => $record['Home address'],
+                'addr_street2' => $record['Home unit'],
+                'addr_city' => $record['Home city'],
+                'addr_state' => $record['Home state'],
+                'addr_zip' => $record['Home zip code'],
+                'source' => env('NORTHSTAR_CLIENT_ID'),
+            ];
+
+            if ($record['Phone']) {
+                $userData['sms_status'] = $record['Opt-in to Partner SMS/robocall'];
+            }
+
+            $user = gateway('northstar')->asClient()->createUser($userData);
+
+            info('created user', ['user' => $user->id]);
+            $this->stats['countUserAccountsCreated']++;
+        }
+
+        return $user;
+    }
+
+    private function getCSVRecords($filepath)
+    {
+        $file = Storage::get($filepath);
+        $csv = Reader::createFromString($file);
+        $csv->setHeaderOffset(0);
+        $records = $csv->getRecords();
+        $this->totalRecords = count($csv);
+
+        event(new LogProgress('Total rows to chomp: ' . $this->totalRecords, 'general'));
+        event(new LogProgress('', 'progress', 0));
+
+        $this->stats['totalRecords'] = $this->totalRecords;
+
+        return $records;
+    }
+}

--- a/app/Jobs/ImportRockTheVotePosts.php
+++ b/app/Jobs/ImportRockTheVotePosts.php
@@ -6,8 +6,8 @@ use Chompy\Stat;
 use Carbon\Carbon;
 use League\Csv\Reader;
 use Chompy\Services\Rogue;
-use Chompy\Events\LogProgress;
 use Illuminate\Bus\Queueable;
+use Chompy\Events\LogProgress;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -271,7 +271,6 @@ class ImportRockTheVotePosts implements ShouldQueue
         return $finalValues;
     }
 
-    // @TODO: is this a thing for RTV??
     /**
      * Parse the record for extra details and return them as a JSON object.
      *
@@ -283,17 +282,9 @@ class ImportRockTheVotePosts implements ShouldQueue
         $details = [];
 
         $importantKeys = [
-            'hostname',
-            'referral-code',
-            'partner-comms-opt-in',
-            'created-at',
-            'updated-at',
-            'voter-registration-status',
-            'voter-registration-source',
-            'voter-registration-method',
-            'voting-method-preference',
-            'email subscribed',
-            'sms subscribed',
+            'Tracking Source',
+            'Started registration',
+            'Finish with State',
         ];
 
         foreach ($importantKeys as $key) {

--- a/app/Jobs/ImportRockTheVotePosts.php
+++ b/app/Jobs/ImportRockTheVotePosts.php
@@ -8,6 +8,7 @@ use League\Csv\Reader;
 use Chompy\Services\Rogue;
 use Illuminate\Bus\Queueable;
 use Chompy\Events\LogProgress;
+use Chompy\Traits\ImportToRogue;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -15,7 +16,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 
 class ImportRockTheVotePosts implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable;
+    use Dispatchable, InteractsWithQueue, Queueable, ImportToRogue;
 
     /**
      * The path to the stored csv.
@@ -150,22 +151,6 @@ class ImportRockTheVotePosts implements ShouldQueue
             'stats' => json_encode($this->stats),
         ]);
 
-    }
-
-    /**
-     * Initiate the stat counters.
-     *
-     * @return array
-     */
-    private function statsInit()
-    {
-        return [
-            'totalRecords' => 0,
-            'countScrubbed' => 0,
-            'countProcessed' => 0,
-            'countPostCreated' => 0,
-            'countUserAccountsCreated' => 0,
-        ];
     }
 
     /**
@@ -439,21 +424,5 @@ class ImportRockTheVotePosts implements ShouldQueue
         }
 
         return $user;
-    }
-
-    private function getCSVRecords($filepath)
-    {
-        $file = Storage::get($filepath);
-        $csv = Reader::createFromString($file);
-        $csv->setHeaderOffset(0);
-        $records = $csv->getRecords();
-        $this->totalRecords = count($csv);
-
-        event(new LogProgress('Total rows to chomp: ' . $this->totalRecords, 'general'));
-        event(new LogProgress('', 'progress', 0));
-
-        $this->stats['totalRecords'] = $this->totalRecords;
-
-        return $records;
     }
 }

--- a/app/Jobs/ImportRockTheVotePosts.php
+++ b/app/Jobs/ImportRockTheVotePosts.php
@@ -60,7 +60,7 @@ class ImportRockTheVotePosts implements ShouldQueue
      *
      * @return void
      */
-    public function handle()
+    public function handle(Rogue $rogue)
     {
         info('STARTING');
 
@@ -71,7 +71,7 @@ class ImportRockTheVotePosts implements ShouldQueue
             $shouldProcess = $this->scrubRecord($record);
 
             if ($shouldProcess) {
-                info('progress_log: Processing: ' . $record['id']);
+                // info('progress_log: Processing: ' . $record['id']); @TODO: do we need this? no nsid column
 
                 $referralCode = $record['Tracking Source'];
                 $referralCodeValues = $this->parseReferralCode($referralCode);
@@ -93,7 +93,6 @@ class ImportRockTheVotePosts implements ShouldQueue
 
                     if (! $post['data']) {
                         $rtvCreatedAtMonth = strtolower(Carbon::parse($record['Started registration'])->format('F-Y'));
-                        // @TODO - is source_details a thing for RTV?
                         $sourceDetails = isset($referralCodeValues['source_details']) ? $referralCodeValues['source_details'] : null;
                         $postDetails = $this->extractDetails($record);
 
@@ -331,11 +330,10 @@ class ImportRockTheVotePosts implements ShouldQueue
     */
     private function scrubRecord($record)
     {
-        $isNotValidEmail = strrpos($record['email'], 'thing.org') !== false || strrpos($record['email'] !== false, '@dosome') || strrpos($record['email'], 'rockthevote.com') !== false || strrpos($record['email'], 'test') !== false || strrpos($record['email'], '+') !== false;
-        $isNotValidHostname = strrpos($record['hostname'], 'testing') !== false;
-        $isNotValidLastName = strrpos($record['last-name'], 'Baloney') !== false;
+        $isNotValidEmail = strrpos($record['Email address'], 'thing.org') !== false || strrpos($record['Email address'] !== false, '@dosome') || strrpos($record['Email address'], 'rockthevote.com') !== false || strrpos($record['Email address'], 'test') !== false || strrpos($record['Email address'], '+') !== false;
+        $isNotValidLastName = strrpos($record['Last name'], 'Baloney') !== false;
 
-        return $isNotValidEmail || $isNotValidHostname || $isNotValidLastName ? false : true;
+        return $isNotValidEmail || $isNotValidLastName ? false : true;
     }
 
     /**
@@ -353,7 +351,7 @@ class ImportRockTheVotePosts implements ShouldQueue
 
         $userFieldsToLookFor = [
             'id' => isset($values['northstar_id']) && !empty($values['northstar_id']) ? $values['northstar_id'] : null,
-            'email' => isset($record['email']) && !empty($record['email']) ? $record['email'] : null,
+            'email' => isset($record['Email address']) && !empty($record['Email address']) ? $record['Email address'] : null,
             'mobile' => isset($record['phone']) && !empty($record['phone']) ? $record['phone'] : null,
         ];
 

--- a/app/Jobs/ImportTurboVotePosts.php
+++ b/app/Jobs/ImportTurboVotePosts.php
@@ -43,7 +43,7 @@ class ImportTurboVotePosts implements ShouldQueue
     {
         $this->filepath = $filepath;
 
-        $this->stats = $this->statsInit();
+        $this->stats = statsInit();
     }
 
 
@@ -151,22 +151,6 @@ class ImportTurboVotePosts implements ShouldQueue
             'total_records' => $this->stats['totalRecords'],
             'stats' => json_encode($this->stats),
         ]);
-    }
-
-    /**
-     * Initiate the stat counters.
-     *
-     * @return array
-     */
-    private function statsInit()
-    {
-        return [
-            'totalRecords' => 0,
-            'countScrubbed' => 0,
-            'countProcessed' => 0,
-            'countPostCreated' => 0,
-            'countUserAccountsCreated' => 0,
-        ];
     }
 
     /**

--- a/app/Traits/ImportToRogue.php
+++ b/app/Traits/ImportToRogue.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Chompy\Traits;
+
+use League\Csv\Reader;
+use Chompy\Events\LogProgress;
+use Illuminate\Support\Facades\Storage;
+
+trait ImportToRogue
+{
+	/**
+	 * Initiate the stat counters to use with imports to Rogue.
+	 *
+	 * @return array
+	 */
+	public function statsInit()
+	{
+	    return [
+	        'totalRecords' => 0,
+	        'countScrubbed' => 0,
+	        'countProcessed' => 0,
+	        'countPostCreated' => 0,
+	        'countUserAccountsCreated' => 0,
+	    ];
+	}
+
+    public function getCSVRecords($filepath)
+    {
+        $file = Storage::get($filepath);
+        $csv = Reader::createFromString($file);
+        $csv->setHeaderOffset(0);
+        $records = $csv->getRecords();
+        $this->totalRecords = count($csv);
+
+        event(new LogProgress('Total rows to chomp: ' . $this->totalRecords, 'general'));
+        event(new LogProgress('', 'progress', 0));
+
+        $this->stats['totalRecords'] = $this->totalRecords;
+
+        return $records;
+    }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,7 @@
         "phpunit/phpunit": "~5.7"
     },
     "autoload": {
-        "classmap": [
-            "database"
-        ],
+        "classmap": ["database"],
         "psr-4": {
             "Chompy\\": "app/"
         }

--- a/config/services.php
+++ b/config/services.php
@@ -66,7 +66,7 @@ return [
         'client_credentials' => [
             'client_id' => env('NORTHSTAR_CLIENT_ID'),
             'client_secret' => env('NORTHSTAR_CLIENT_SECRET'),
-            'scope' => ['admin', 'user', 'client', 'activity', 'write'],
+            'scope' => ['admin', 'user', 'activity', 'write'],
         ],
     ]
 

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -21,8 +21,10 @@
             <div class="form-check">
                 <label class="form-check-label">
                     <!-- @TODO - make "checked" status a variable that has a default -->
-                    <input checked name="import-type" class="form-check-input" type="checkbox" value="turbovote">
+                    <input name="import-type" class="form-check-input" type="checkbox" value="turbovote">
                     TurboVote Import
+                    <input name="import-type" class="form-check-input" type="checkbox" value="rock-the-vote">
+                    Rock the Vote Import
                 </label>
             </div>
         </div>

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -23,6 +23,7 @@
                     <!-- @TODO - make "checked" status a variable that has a default -->
                     <input name="import-type" class="form-check-input" type="checkbox" value="turbovote">
                     TurboVote Import
+                    <br>
                     <input name="import-type" class="form-check-input" type="checkbox" value="rock-the-vote">
                     Rock the Vote Import
                 </label>


### PR DESCRIPTION
I've finally tested this enough locally to merge and do some testing on QA.

This includes:
1. The job to import Rock The Vote information into Rogue. This is based on [this detailed write-up](https://github.com/DoSomething/chompy/wiki/How-Rock-The-Vote-(RTV)-records-are-imported) and I can provide an example file if you'd like one.

2. Adds a checkbox for the Rock The Vote import.

3. Removes `client` from the scopes we get from Northstar, we don't need it!

This is a big pile of code and we are going to test thoroughly on QA, but please let me know if you have any questions or if there is anything I can explain better! It gets pretty gritty but I tried to include some helpful comments.