### PR TITLE
Add status to post details for RTV

### DIFF
--- a/app/Jobs/ImportRockTheVotePosts.php
+++ b/app/Jobs/ImportRockTheVotePosts.php
@@ -275,6 +275,7 @@ class ImportRockTheVotePosts implements ShouldQueue
             'Tracking Source',
             'Started registration',
             'Finish with State',
+            'Status',
         ];
 
         foreach ($importantKeys as $key) {


### PR DESCRIPTION
We just want to add another field ("Status") to the `details` on the post when creating a new post in Rogue. We decided that it makes more sense to include this as well as "Finish with State" because those are the two fields used to determine the overall `status` of the post.