### PR TITLE
Include email and zip in post details for RTV

### DIFF
--- a/app/Jobs/ImportRockTheVotePosts.php
+++ b/app/Jobs/ImportRockTheVotePosts.php
@@ -276,6 +276,8 @@ class ImportRockTheVotePosts implements ShouldQueue
             'Started registration',
             'Finish with State',
             'Status',
+            'Email address',
+            'Home zip code'
         ];
 
         foreach ($importantKeys as $key) {


### PR DESCRIPTION
#### What's this PR do?
Adds `email` and `zip` that a user provided when registering to vote through Rock The Vote to the `details` column if we are creating a new post in Rogue.

#### How should this be reviewed?
Will this add those two fields?

#### Any background context you want to provide?
Need by data woo!

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/159282310)
