### PR TITLE
updates how we send created_at to Rogue

### DIFF
--- a/app/Jobs/ImportFacebookSharePosts.php
+++ b/app/Jobs/ImportFacebookSharePosts.php
@@ -69,7 +69,7 @@ class ImportFacebookSharePosts implements ShouldQueue
         foreach ($records as $offset => $record) {
             info('process_log: Processing: ' . $record['_id']);
             $postData = [
-                'campaign_id' => (int) $record['campaign_id'],
+                'campaign_id' => $record['campaign_id'],
                 'campaign_run_id' => (int) $record['campaign_run'],
                 'northstar_id' => $record['user.northstarId'],
                 'type' => 'share-social',
@@ -78,10 +78,10 @@ class ImportFacebookSharePosts implements ShouldQueue
                 'status' => 'accepted',
                 'source' => 'importer-client',
                 'source_details' => json_encode(['original-source' => $record['event.source']]),
-                'created_at' => strtotime($record['to_timestamp']),
+                'created_at' => date(DATE_ATOM, strtotime($record['to_timestamp'])),
             ];
-
             try {
+                // dd((($postData['created_at'])));
                 $post = $rogue->createPost($postData);
 
                 if ($post['data']) {

--- a/app/Jobs/ImportFacebookSharePosts.php
+++ b/app/Jobs/ImportFacebookSharePosts.php
@@ -2,6 +2,7 @@
 
 namespace Chompy\Jobs;
 
+use Carbon\Carbon;
 use League\Csv\Reader;
 use Chompy\Services\Rogue;
 use Illuminate\Bus\Queueable;
@@ -78,7 +79,7 @@ class ImportFacebookSharePosts implements ShouldQueue
                 'status' => 'accepted',
                 'source' => 'importer-client',
                 'source_details' => json_encode(['original-source' => $record['event.source']]),
-                'created_at' => date(DATE_ATOM, strtotime($record['to_timestamp'])),
+                'created_at' => Carbon::parse($record['to_timestamp'])->toDateTimeString(),
             ];
             try {
                 $post = $rogue->createPost($postData);

--- a/app/Jobs/ImportFacebookSharePosts.php
+++ b/app/Jobs/ImportFacebookSharePosts.php
@@ -81,7 +81,6 @@ class ImportFacebookSharePosts implements ShouldQueue
                 'created_at' => date(DATE_ATOM, strtotime($record['to_timestamp'])),
             ];
             try {
-                // dd((($postData['created_at'])));
                 $post = $rogue->createPost($postData);
 
                 if ($post['data']) {


### PR DESCRIPTION
#### What's this PR do?
Sends `created_at` time in correct format that we want to send to Rogue. 

#### How should this be reviewed?
👀 

#### Relevant tickets
[This](https://www.pivotaltracker.com/n/projects/2019429/stories/156165836) Pivotal Card and this PR in Rogue.
