### PR TITLE
adds `_id` to details json in Historic FB Shares

### DIFF
--- a/app/Jobs/ImportFacebookSharePosts.php
+++ b/app/Jobs/ImportFacebookSharePosts.php
@@ -75,7 +75,7 @@ class ImportFacebookSharePosts implements ShouldQueue
                 'northstar_id' => $record['user.northstarId'],
                 'type' => 'share-social',
                 'action' => $record['action'],
-                'details' => json_encode(['platform' => 'facebook']),
+                'details' => json_encode(['platform' => 'facebook', '_id' => $record['_id']]),
                 'status' => 'accepted',
                 'source' => 'importer-client',
                 'source_details' => json_encode(['original-source' => $record['event.source']]),


### PR DESCRIPTION
#### What's this PR do?
adds `_id` to `details` json in Historic FB Shares so it will look like this:
```
{
  'platform': 'facebook',
  '_id': 5b201dfdeb77630004790a85,
}
```

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
From request in convo [here](https://dosomething.slack.com/archives/CA0N5FXND/p1533826403000235?thread_ts=1533755010.000294&cid=CA0N5FXND)

#### Relevant tickets
Continued work from #34 
