### PR TITLE
RTV: Make sure campaign ids are integers before using

### DIFF
--- a/app/Jobs/CreateRockTheVotePostInRogue.php
+++ b/app/Jobs/CreateRockTheVotePostInRogue.php
@@ -192,8 +192,8 @@ class CreateRockTheVotePostInRogue implements ShouldQueue
 
         // See if we have all the required information we need
         if (!array_has($values, ['northstar_id', 'campaign_id', 'campaign_run_id'])) {
-            // If we have the campaign values, use em! This also means that we do not have NS id
-            if (array_has($values, ['campaign_id', 'campaign_run_id'])) {
+            // If we have valid campaign values, use em! This also means that we do not have NS id
+            if (array_has($values, ['campaign_id', 'campaign_run_id']) && is_numeric($values['campaign_id']) && is_numeric($values['campaign_run_id'])) {
                 $finalValues = [
                     'northstar_id' => null, // set the user to null so we force account creation when the code is not present.
                     'campaign_id' => $values['campaign_id'],


### PR DESCRIPTION
#### What's this PR do?
- Adds an additional check before we use the given campaign id and run id. We used to just use them if both existed, now we only use them if both exist AND ARE INTEGERS.

#### How should this be reviewed?
Does it do what I think it does?

#### Any background context you want to provide?
We get some wild tracking sources, but we don't want that to break anything.

#### Relevant tickets

[Card](https://www.pivotaltracker.com/story/show/160321941)
