### PR TITLE
increases upload_max-filesize and adds post_max_size

### DIFF
--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,2 +1,3 @@
-upload_max_filesize = 10M
+upload_max_filesize = 1000M
 memory_limit = 256M
+post_max_size = 1000M

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,3 +1,3 @@
-upload_max_filesize = 2000M
-memory_limit = 2048M
-post_max_size = 2000M
+upload_max_filesize = 500M
+memory_limit = 512M
+post_max_size = 500M

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,3 +1,3 @@
-upload_max_filesize = 1000M
+upload_max_filesize = 2000M
 memory_limit = 256M
-post_max_size = 1000M
+post_max_size = 2000M

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,3 +1,3 @@
 upload_max_filesize = 2000M
-memory_limit = 256M
+memory_limit = 2048M
 post_max_size = 2000M


### PR DESCRIPTION
#### What's this PR do?
When uploading a large RTV file, Chompy breaks - it tries to upload the large file and in the bottom left corner of my browser says “Uploading 5%” and then keeps restarting and then breaks with this image: 
![screen shot 2018-09-21 at 1 49 35 pm](https://user-images.githubusercontent.com/9019452/45900080-a7ada600-bdac-11e8-9ac9-874f34b6a525.png)

In the logs, I see `PHP Warning:  POST Content-Length of 20804247 bytes exceeds the limit of 8388608 bytes in Unknown on line 0` and `"Server Request Interrupted" method=POST path="/import" host=importer-qa.dosomething.org request_id=5af63bcd-4c70-45dd-bcaa-962febf1a4ba fwd="73.61.23.2" dyno=web.1 connect=0ms service=301ms status=503 bytes=21023 protocol=https `. This PR increases `upload_max-filesize` and adds `post_max_size` to hopefully fix this error. 

#### How should this be reviewed?
👀 

#### Relevant tickets
Related to work done in this PR: #47 
