### PR TITLE
Send voter reg status to Northstar

### DIFF
--- a/app/Jobs/CreateRockTheVotePostInRogue.php
+++ b/app/Jobs/CreateRockTheVotePostInRogue.php
@@ -55,6 +55,7 @@ class CreateRockTheVotePostInRogue implements ShouldQueue
             }
 
             if (isset($user)) {
+                // @TODO: If we write more functions that are identical across all voter reg imports, pull out into a ImportsVoterReg trait
                 $this->updateNorthstarStatus($user, $this->translateStatus($this->record['Status'], $this->record['Finish with State']));
 
                 $post = $rogue->getPost([

--- a/app/Jobs/CreateTurboVotePostInRogue.php
+++ b/app/Jobs/CreateTurboVotePostInRogue.php
@@ -55,6 +55,7 @@ class CreateTurboVotePostInRogue implements ShouldQueue
             }
 
             if (isset($user)) {
+                // @TODO: If we write more functions that are identical across all voter reg imports, pull out into a ImportsVoterReg trait
                 $this->updateNorthstarStatus($user, $this->translateTVStatus($this->record['voter-registration-status'], $this->record['voter-registration-method']));
 
                 $post = $rogue->getPost([


### PR DESCRIPTION
#### What's this PR do?
- Added a `updateNorthstarStatus` function to each voter reg import. I know before we've had stuff as traits but I think that makes it a little harder for debugging. Open to suggestions!
- Call this function after we get or create a user.

#### How should this be reviewed?

If you run an import, do these users have `voter_registration_status` set in Northstar?

#### Any background context you want to provide?

Before merge: Update Northstar to have a `voter_registration_status` setter that only allows this field to move up the hierarchy.

#### Relevant tickets

[Card](https://www.pivotaltracker.com/story/show/160103784)
