### PR TITLE
if status is under 18, change to ineligible

### DIFF
--- a/app/Jobs/CreateRockTheVotePostInRogue.php
+++ b/app/Jobs/CreateRockTheVotePostInRogue.php
@@ -326,7 +326,7 @@ class CreateRockTheVotePostInRogue implements ShouldQueue
             return 'uncertain';
         }
 
-        if ($rtvStatus === 'rejected') {
+        if ($rtvStatus === 'rejected' || $rtvStatus === 'under 18') {
             return 'ineligible';
         }
 


### PR DESCRIPTION
#### What's this PR do?
If the `Status` in the RTV csv is `Under 18`, translate status to `ineligible` so it doesn't fail [NS validation](https://github.com/DoSomething/northstar/blob/master/app/Auth/Registrar.php#L78). 

#### How should this be reviewed?
Is this logic correct? 

#### Any background context you want to provide?
Background info in [Slack chat](https://dosomething.slack.com/archives/CA0N5FXND/p1540236497000100?thread_ts=1540234066.000100&cid=CA0N5FXND).
