### PR TITLE
removes campaign_run_id from  in fb share import

### DIFF
--- a/app/Jobs/ImportFacebookSharePosts.php
+++ b/app/Jobs/ImportFacebookSharePosts.php
@@ -83,7 +83,6 @@ class ImportFacebookSharePosts implements ShouldQueue
             if (! $post['data']) {
                 $postData = [
                     'campaign_id' => $record['campaign_id'],
-                    'campaign_run_id' => (int) $record['campaign_run'],
                     'northstar_id' => $record['user.northstarId'],
                     'type' => 'share-social',
                     'action' => $record['action'],


### PR DESCRIPTION
#### What's this PR do?
removes `campaign_run_id` from  in fb share import job since we have 🔪 runs

#### How should this be reviewed?
👀 

#### Relevant tickets

Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/163024880) Pivotal Card.
