### PR TITLE
Persist selected import type on webform

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -27,7 +27,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/import';
+    protected $redirectTo = '/';
 
     /**
      * Where to redirect users after logout.

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -58,17 +58,17 @@ class ImportController extends Controller
 
         $type = $request->input('import-type');
 
-        if ($type === 'turbovote') {
+        if ($type === get_import_type_turbovote()) {
             info("turbo vote import happening");
             ImportTurboVotePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        if ($type === 'rock-the-vote') {
+        if ($type === get_import_type_rock_the_vote()) {
             info('rock the vote import happening');
             ImportRockTheVotePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        if ($type === 'facebook') {
+        if ($type === get_import_type_facebook()) {
             info("Facebook share import happening");
             ImportFacebookSharePosts::dispatch($path)->delay(now()->addSeconds(3));
         }

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -58,17 +58,17 @@ class ImportController extends Controller
 
         $type = $request->input('import-type');
 
-        if ($type === get_import_type_turbovote()) {
+        if ($type === \Chompy\ImportType::$turbovote) {
             info("turbo vote import happening");
             ImportTurboVotePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        if ($type === get_import_type_rock_the_vote()) {
+        if ($type === \Chompy\ImportType::$rockTheVote) {
             info('rock the vote import happening');
             ImportRockTheVotePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        if ($type === get_import_type_facebook()) {
+        if ($type === \Chompy\ImportType::$facebook) {
             info("Facebook share import happening");
             ImportFacebookSharePosts::dispatch($path)->delay(now()->addSeconds(3));
         }

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -56,21 +56,23 @@ class ImportController extends Controller
             throw new HttpException(500, 'Unable read and store file to S3.');
         }
 
-        if ($request->input('import-type') === 'turbovote') {
+        $type = $request->input('import-type');
+
+        if ($type === 'turbovote') {
             info("turbo vote import happening");
             ImportTurboVotePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        if ($request->input('import-type') === 'rock-the-vote') {
+        if ($type === 'rock-the-vote') {
             info('rock the vote import happening');
             ImportRockTheVotePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        if ($request->input('import-type') === 'facebook') {
+        if ($type === 'facebook') {
             info("Facebook share import happening");
             ImportFacebookSharePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        return redirect()->route('import.show')->with('status', 'Your CSV was added to the queue to be processed.');
+        return redirect()->route('import.show', ['type' => $type])->with('status', 'Your CSV was added to the queue to be processed.');
     }
 }

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -9,6 +9,7 @@ use Chompy\Jobs\ImportTurboVotePosts;
 use Chompy\Jobs\ImportFacebookSharePosts;
 use Illuminate\Support\Facades\Storage;
 use Chompy\Jobs\ImportRockTheVotePosts;
+use Chompy\ImportType;
 
 class ImportController extends Controller
 {
@@ -58,17 +59,17 @@ class ImportController extends Controller
 
         $type = $request->input('import-type');
 
-        if ($type === \Chompy\ImportType::$turbovote) {
+        if ($type === ImportType::$turbovote) {
             info("turbo vote import happening");
             ImportTurboVotePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        if ($type === \Chompy\ImportType::$rockTheVote) {
+        if ($type === ImportType::$rockTheVote) {
             info('rock the vote import happening');
             ImportRockTheVotePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        if ($type === \Chompy\ImportType::$facebook) {
+        if ($type === ImportType::$facebook) {
             info("Facebook share import happening");
             ImportFacebookSharePosts::dispatch($path)->delay(now()->addSeconds(3));
         }

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -18,7 +18,7 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect('/import');
+            return redirect('/');
         }
 
         return $next($request);

--- a/app/Import.php
+++ b/app/Import.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Chompy;
+
+class ImportType {
+  public static $facebook = 'facebook';
+  public static $rockTheVote = 'rock-the-vote';
+  public static $turbovote = 'turbovote';
+
+  public static function all() {
+    return [self::$facebook, self::$rockTheVote, self::$turbovote];
+  }
+}

--- a/app/Import.php
+++ b/app/Import.php
@@ -2,12 +2,35 @@
 
 namespace Chompy;
 
-class ImportType {
-  public static $facebook = 'facebook';
-  public static $rockTheVote = 'rock-the-vote';
-  public static $turbovote = 'turbovote';
+class ImportType
+{
+    /**
+     * A Facebook share import type.
+     *
+     * @var string
+     */
+    public static $facebook = 'facebook';
 
-  public static function all() {
-    return [self::$facebook, self::$rockTheVote, self::$turbovote];
-  }
+    /**
+     * A Rock The Vote import type.
+     *
+     * @var string
+     */
+    public static $rockTheVote = 'rock-the-vote';
+
+    /**
+     * A Turbovote import type.
+     *
+     * @var string
+     */
+    public static $turbovote = 'turbovote';
+
+    /**
+     * Returns list of all valid import types.
+     *
+     * @return array
+     */
+    public static function all() {
+        return [self::$facebook, self::$rockTheVote, self::$turbovote];
+    }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,46 +1,6 @@
 <?php
 
 /**
- * Returns import type for Facebook share files.
- * @return string
- */
-function get_import_type_facebook()
-{
-  return 'facebook';
-}
-
-/**
- * Returns import type for Rock the Vote files.
- * @return string
- */
-function get_import_type_rock_the_vote()
-{
-  return 'rock-the-vote';
-}
-
-/**
- * Returns import type for Turbovote files.
- * @return string
- */
-function get_import_type_turbovote()
-{
-  return 'turbovote';
-}
-
-/**
- * Returns array of supported import types.
- * @return array
- */
-function get_import_types()
-{
-    return [
-      get_import_type_facebook(),
-      get_import_type_rock_the_vote(),
-      get_import_type_turbovote(),
-    ];
-}
-
-/**
  * Parse a string as boolean.
  *
  * @param string $text

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * Returns import type of Facebook share files.
+ * Returns import type for Facebook share files.
+ * @return string
  */
 function get_import_type_facebook()
 {
@@ -9,7 +10,7 @@ function get_import_type_facebook()
 }
 
 /**
- * Returns import type of Rock the Vote files.
+ * Returns import type for Rock the Vote files.
  * @return string
  */
 function get_import_type_rock_the_vote()
@@ -18,7 +19,7 @@ function get_import_type_rock_the_vote()
 }
 
 /**
- * Returns import type of Turbovote files.
+ * Returns import type for Turbovote files.
  * @return string
  */
 function get_import_type_turbovote()

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -3,7 +3,8 @@
 /**
  * Returns import type of Facebook share files.
  */
-function get_import_type_facebook() {
+function get_import_type_facebook()
+{
   return 'facebook';
 }
 
@@ -11,7 +12,8 @@ function get_import_type_facebook() {
  * Returns import type of Rock the Vote files.
  * @return string
  */
-function get_import_type_rock_the_vote() {
+function get_import_type_rock_the_vote()
+{
   return 'rock-the-vote';
 }
 
@@ -19,7 +21,8 @@ function get_import_type_rock_the_vote() {
  * Returns import type of Turbovote files.
  * @return string
  */
-function get_import_type_turbovote() {
+function get_import_type_turbovote()
+{
   return 'turbovote';
 }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,7 +1,43 @@
 <?php
 
 /**
- * Parse a CSV field value as boolean.
+ * Returns import type of Facebook share files.
+ */
+function get_import_type_facebook() {
+  return 'facebook';
+}
+
+/**
+ * Returns import type of Rock the Vote files.
+ * @return string
+ */
+function get_import_type_rock_the_vote() {
+  return 'rock-the-vote';
+}
+
+/**
+ * Returns import type of Turbovote files.
+ * @return string
+ */
+function get_import_type_turbovote() {
+  return 'turbovote';
+}
+
+/**
+ * Returns array of supported import types.
+ * @return array
+ */
+function get_import_types()
+{
+    return [
+      get_import_type_facebook(),
+      get_import_type_rock_the_vote(),
+      get_import_type_turbovote(),
+    ];
+}
+
+/**
+ * Parse a string as boolean.
  *
  * @param string $text
  * @return boolean

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -13,13 +13,15 @@
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
-                    <li>
+                    <li class="{{ (isset($_GET['type']) && $_GET['type'] === 'turbovote') ? 'active' : '' }}">
                         <a class="nav-item nav-link" href="/import?type=turbovote">TurboVote</a>
                     </li>
-                    <li>
-                        <a class="nav-item nav-link" href="/import?type=rock-the-vote">Rock The Vote</a></li>
-                    <li>
-                        <a class="nav-item nav-link" href="/import?type=facebook">Facebook Share</a></li>
+                    <li class="{{ (isset($_GET['type']) && $_GET['type'] === 'rock-the-vote') ? 'active' : '' }}">
+                        <a class="nav-item nav-link" href="/import?type=rock-the-vote">Rock The Vote</a>
+                    </li>
+                    <li class="{{ (isset($_GET['type']) && $_GET['type'] === 'facebook') ? 'active' : '' }}">
+                        <a class="nav-item nav-link" href="/import?type=facebook">Facebook Share</a>
+                    </li>
                     <li>
                         <a class="nav-item nav-link" href="/logout">Logout</a>
                     </li>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -13,18 +13,18 @@
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
-                    <li class="{{ (app('request')->input('type') === get_import_type_turbovote()) ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type={{ get_import_type_turbovote() }}">
+                    <li class="{{ request()->input('type') === \Chompy\ImportType::$turbovote ? 'active' : '' }}">
+                        <a class="nav-item nav-link" href="/import?type={{ \Chompy\ImportType::$turbovote }}">
                             TurboVote
                         </a>
                     </li>
-                    <li class="{{ (app('request')->input('type') === get_import_type_rock_the_vote()) ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type={{ get_import_type_rock_the_vote() }}">
+                    <li class="{{ request()->input('type') === \Chompy\ImportType::$rockTheVote ? 'active' : '' }}">
+                        <a class="nav-item nav-link" href="/import?type={{ \Chompy\ImportType::$rockTheVote }}">
                             Rock The Vote
                         </a>
                     </li>
-                    <li class="{{ (app('request')->input('type') === get_import_type_facebook()) ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type={{ get_import_type_facebook() }}">
+                    <li class="{{ request()->input('type') === \Chompy\ImportType::$facebook ? 'active' : '' }}">
+                        <a class="nav-item nav-link" href="/import?type={{ \Chompy\ImportType::$facebook }}">
                             Facebook Share
                         </a>
                     </li>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -13,14 +13,20 @@
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
-                    <li class="{{ (app('request')->input('type') === 'turbovote') ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type=turbovote">TurboVote</a>
+                    <li class="{{ (app('request')->input('type') === get_import_type_turbovote()) ? 'active' : '' }}">
+                        <a class="nav-item nav-link" href="/import?type={{get_import_type_turbovote()}}">
+                            TurboVote
+                        </a>
                     </li>
-                    <li class="{{ (app('request')->input('type') === 'rock-the-vote') ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type=rock-the-vote">Rock The Vote</a>
+                    <li class="{{ (app('request')->input('type') === get_import_type_rock_the_vote()) ? 'active' : '' }}">
+                        <a class="nav-item nav-link" href="/import?type={{get_import_type_rock_the_vote()}}">
+                            Rock The Vote
+                        </a>
                     </li>
-                    <li class="{{ (app('request')->input('type') === 'facebook') ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type=facebook">Facebook Share</a>
+                    <li class="{{ (app('request')->input('type') === get_import_type_facebook()) ? 'active' : '' }}">
+                        <a class="nav-item nav-link" href="/import?type={{get_import_type_facebook()}}">
+                            Facebook Share
+                        </a>
                     </li>
                     <li>
                         <a class="nav-item nav-link" href="/logout">Logout</a>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -14,17 +14,17 @@
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
                     <li class="{{ (app('request')->input('type') === get_import_type_turbovote()) ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type={{get_import_type_turbovote()}}">
+                        <a class="nav-item nav-link" href="/import?type={{ get_import_type_turbovote() }}">
                             TurboVote
                         </a>
                     </li>
                     <li class="{{ (app('request')->input('type') === get_import_type_rock_the_vote()) ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type={{get_import_type_rock_the_vote()}}">
+                        <a class="nav-item nav-link" href="/import?type={{ get_import_type_rock_the_vote() }}">
                             Rock The Vote
                         </a>
                     </li>
                     <li class="{{ (app('request')->input('type') === get_import_type_facebook()) ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type={{get_import_type_facebook()}}">
+                        <a class="nav-item nav-link" href="/import?type={{ get_import_type_facebook() }}">
                             Facebook Share
                         </a>
                     </li>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -13,13 +13,13 @@
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
-                    <li class="{{ (isset($_GET['type']) && $_GET['type'] === 'turbovote') ? 'active' : '' }}">
+                    <li class="{{ (app('request')->input('type') === 'turbovote') ? 'active' : '' }}">
                         <a class="nav-item nav-link" href="/import?type=turbovote">TurboVote</a>
                     </li>
-                    <li class="{{ (isset($_GET['type']) && $_GET['type'] === 'rock-the-vote') ? 'active' : '' }}">
+                    <li class="{{ (app('request')->input('type') === 'rock-the-vote') ? 'active' : '' }}">
                         <a class="nav-item nav-link" href="/import?type=rock-the-vote">Rock The Vote</a>
                     </li>
-                    <li class="{{ (isset($_GET['type']) && $_GET['type'] === 'facebook') ? 'active' : '' }}">
+                    <li class="{{ (app('request')->input('type') === 'facebook') ? 'active' : '' }}">
                         <a class="nav-item nav-link" href="/import?type=facebook">Facebook Share</a>
                     </li>
                     <li>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -13,8 +13,16 @@
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
-                    <li><a class="nav-item nav-link" href="/import">Import</a></li>
-                    <li><a class="nav-item nav-link" href="/logout">Logout</a></li>
+                    <li>
+                        <a class="nav-item nav-link" href="/import?type=turbovote">TurboVote</a>
+                    </li>
+                    <li>
+                        <a class="nav-item nav-link" href="/import?type=rock-the-vote">Rock The Vote</a></li>
+                    <li>
+                        <a class="nav-item nav-link" href="/import?type=facebook">Facebook Share</a></li>
+                    <li>
+                        <a class="nav-item nav-link" href="/logout">Logout</a>
+                    </li>
                 @else
                     <li><a class="nav-item nav-link" href="/login">Login</a></li>
                 @endif

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -8,27 +8,12 @@
         <div class="form-group">
             <div class="input-group">
                 <label class="input-group-btn">
-                    <span class="btn btn-primary">
+                    <span class="btn btn-default">
                         Browse <input type="file" name="upload-file" style="display: none;" multiple>
                     </span>
                 </label>
+                <input type="hidden" name="import-type" value={{ app('request')->input('type') }}>
                 <input type="text" class="form-control" readonly>
-            </div>
-        </div>
-
-        <div class="form-group">
-            <label>Import Type</label>
-            <div class="form-check">
-                <label class="form-check-label">
-                    <input name="import-type" class="form-check-input" type="radio" value="turbovote" {{ (isset($_GET['type']) && $_GET['type'] === 'turbovote') ? 'checked' : '' }} >
-                    TurboVote
-                    <br>
-                    <input name="import-type" class="form-check-input" type="radio" value="rock-the-vote" {{ (isset($_GET['type']) && $_GET['type'] === 'rock-the-vote') ? 'checked' : '' }} >
-                    Rock the Vote
-                    <br>
-                    <input name="import-type" class="form-check-input" type="radio" value="facebook" {{ (isset($_GET['type']) && $_GET['type'] === 'facebook') ? 'checked' : '' }} >
-                    Facebook Share
-                </label>
             </div>
         </div>
         <div>

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -2,7 +2,7 @@
 
 @section('main_content')
 
-@if (in_array(app('request')->input('type'), get_import_types()))
+@if (in_array(request()->input('type'), \Chompy\ImportType::all()))
     <div>
         <form action={{url('/import')}} method="post" enctype="multipart/form-data">
             {{ csrf_field() }}

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -5,7 +5,7 @@
 @if (in_array(app('request')->input('type'), get_import_types()))
     <div>
         <form action={{url('/import')}} method="post" enctype="multipart/form-data">
-            {{ csrf_field()}}
+            {{ csrf_field() }}
             <div class="form-group">
                 <div class="input-group">
                     <label class="input-group-btn">

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -17,18 +17,17 @@
         </div>
 
         <div class="form-group">
-            <label>Type of Import</label>
+            <label>Import Type</label>
             <div class="form-check">
                 <label class="form-check-label">
-                    <!-- @TODO - make "checked" status a variable that has a default -->
-                    <input name="import-type" class="form-check-input" type="radio" value="turbovote">
-                    TurboVote Import
+                    <input name="import-type" class="form-check-input" type="radio" value="turbovote" {{ (isset($_GET['type']) && $_GET['type'] === 'turbovote') ? 'checked' : '' }} >
+                    TurboVote
                     <br>
-                    <input name="import-type" class="form-check-input" type="radio" value="rock-the-vote">
-                    Rock the Vote Import
+                    <input name="import-type" class="form-check-input" type="radio" value="rock-the-vote" {{ (isset($_GET['type']) && $_GET['type'] === 'rock-the-vote') ? 'checked' : '' }} >
+                    Rock the Vote
                     <br>
-                    <input name="import-type" class="form-check-input" type="radio" value="facebook">
-                    Facebook Share Import
+                    <input name="import-type" class="form-check-input" type="radio" value="facebook" {{ (isset($_GET['type']) && $_GET['type'] === 'facebook') ? 'checked' : '' }} >
+                    Facebook Share
                 </label>
             </div>
         </div>

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -2,31 +2,33 @@
 
 @section('main_content')
 
-<div>
-    <form action={{url('/import')}} method="post" enctype="multipart/form-data">
-        {{ csrf_field()}}
-        <div class="form-group">
-            <div class="input-group">
-                <label class="input-group-btn">
-                    <span class="btn btn-default">
-                        Browse <input type="file" name="upload-file" style="display: none;" multiple>
-                    </span>
-                </label>
-                <input type="hidden" name="import-type" value={{ app('request')->input('type') }}>
-                <input type="text" class="form-control" readonly>
+@if (in_array(app('request')->input('type'), ['facebook', 'rock-the-vote', 'turbovote']))
+    <div>
+        <form action={{url('/import')}} method="post" enctype="multipart/form-data">
+            {{ csrf_field()}}
+            <div class="form-group">
+                <div class="input-group">
+                    <label class="input-group-btn">
+                        <span class="btn btn-default">
+                            Browse <input type="file" name="upload-file" style="display: none;" multiple>
+                        </span>
+                    </label>
+                    <input type="hidden" name="import-type" value={{ app('request')->input('type') }}>
+                    <input type="text" class="form-control" readonly>
+                </div>
             </div>
-        </div>
-        <div>
-            <input type="submit" class="btn btn-primary" value="Submit CSV">
-        </div>
-    </form>
-</div>
-<h2>Progress Log</h2>
-<div id="messages">
-    <!--Messages goes here-->
-</div>
-<div class="progress">
-    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div>
-</div>
+            <div>
+                <input type="submit" class="btn btn-primary" value="Submit CSV">
+            </div>
+        </form>
+    </div>
+    <h2>Progress Log</h2>
+    <div id="messages">
+        <!--Messages goes here-->
+    </div>
+    <div class="progress">
+        <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div>
+    </div>
+@endif
 
 @endsection

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -2,7 +2,7 @@
 
 @section('main_content')
 
-@if (in_array(app('request')->input('type'), ['facebook', 'rock-the-vote', 'turbovote']))
+@if (in_array(app('request')->input('type'), get_import_types()))
     <div>
         <form action={{url('/import')}} method="post" enctype="multipart/form-data">
             {{ csrf_field()}}


### PR DESCRIPTION
#### What's this PR do?

Branching off of #58, this PR refactors the import form to post the `import-type` parameter via a query string, set by new nav links for each import type. As I was testing #58, I thought it'd be nice to get to know the app a bit better (and help make it  slightly less tedious to repeatedly test) by fixing the TODO for pre-selecting an import type.

<img width="500" alt="screen shot 2019-02-13 at 3 05 50 pm" src="https://user-images.githubusercontent.com/1236811/52750366-dff29280-2fa0-11e9-9226-96908fb0c78f.png">


#### How should this be reviewed?

* Verify that logging in directs you to the homepage, and that the "Import" link/form is separated into three links per import type. 

* Verify import form works per each selected import type, and that you are redirected to the same import type form after successful submit

* Verify import form is hidden if type query parameter is not one of `turbovote`, `rock-the-vote`, or `facebook`

#### Relevant tickets

Support to make testing https://www.pivotaltracker.com/story/show/163564896 easier
