### PR TITLE
RTV Cleanup: Part 1

### DIFF
--- a/app/Jobs/CreateRockTheVotePostInRogue.php
+++ b/app/Jobs/CreateRockTheVotePostInRogue.php
@@ -142,6 +142,7 @@ class RockTheVoteRecord {
 
         return $finalValues;
     }
+
     /**
      * Translate a status from Rock The Vote into a status that can be sent to Rogue.
      *
@@ -152,18 +153,12 @@ class RockTheVoteRecord {
     private function parseVoterRegistrationStatus($rtvStatus, $rtvFinishWithState)
     {
         $rtvStatus = strtolower($rtvStatus);
-        $rtvFinishWithState = strtolower($rtvFinishWithState);
 
-        if($rtvStatus === 'complete') {
-            if ($rtvFinishWithState === "no") {
-                return 'register-form';
-            }
-            if ($rtvFinishWithState === "yes") {
-                return 'register-OVR';
-            }
+        if ($rtvStatus === 'complete') {
+            return str_to_boolean($rtvFinishWithState) ? 'register-OVR' : 'register-form';
         }
 
-        if (strpos($rtvStatus, 'step') !== false) {
+        if (str_contains($rtvStatus, 'step') !== false) {
             return 'uncertain';
         }
 

--- a/app/Jobs/CreateRockTheVotePostInRogue.php
+++ b/app/Jobs/CreateRockTheVotePostInRogue.php
@@ -263,7 +263,7 @@ class CreateRockTheVotePostInRogue implements ShouldQueue
      * TODO: Move this to DRY with TurboVote imports (if we keep it).
      * @see https://www.pivotaltracker.com/n/projects/2019429/stories/164114650
      *
-     * @param  string $data
+     * @param string $data
      * @return NorthstarUser
      */
     private function getUser($data)

--- a/app/Jobs/CreateRockTheVotePostInRogue.php
+++ b/app/Jobs/CreateRockTheVotePostInRogue.php
@@ -53,7 +53,7 @@ class CreateRockTheVotePostInRogue implements ShouldQueue
      */
     public function handle(Rogue $rogue)
     {
-    	if ($this->isTestData($this->record)) {
+    	if (is_test_email($this->data->email)) {
             info('progress_log: Skipping test: ' . $this->data->email);
             return;
         }
@@ -110,21 +110,6 @@ class CreateRockTheVotePostInRogue implements ShouldQueue
         if ($statusShouldChange) {
             $rogue->updatePost($postId, ['status' => $statusShouldChange]);
         }
-    }
-
-    /*
-     * Returns whether a record is test data that should not create/update users and/or posts.
-     * TODO: Move this into helpers and DRY with any other Jobs that are still relevant.
-     *
-     * @param array $record
-     * @return bool
-     */
-    private function isTestData($record)
-    {
-        $isNotValidEmail = strrpos($record['Email address'], 'thing.org') !== false || strrpos($record['Email address'] !== false, '@dosome') || strrpos($record['Email address'], 'rockthevote.com') !== false || strrpos($record['Email address'], 'test') !== false || strrpos($record['Email address'], '+') !== false;
-        $isNotValidLastName = strrpos($record['Last name'], 'Baloney') !== false;
-
-        return $isNotValidEmail || $isNotValidLastName ? true : false;
     }
 
     /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Str;
  */
 function is_test_email($email)
 {
-    return Str::contains($email, ['thing.org', '@dosome','rockthevote.com', 'test', '+']);
+    return Str::contains($email, ['@dosomething.org', '@example']);
 }
 
 /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,18 @@
 <?php
 
+use Illuminate\Support\Str;
+
+/**
+ * Returns whether email is a test email.
+ *
+ * @param string $email
+ * @return boolean
+ */
+function is_test_email($email)
+{
+    return Str::contains($email, ['thing.org', '@dosome','rockthevote.com', 'test', '+']);
+}
+
 /**
  * Parse a string as boolean.
  *


### PR DESCRIPTION
#### What's this PR do?

Moves parsing a referral code into the  `RockTheVoteRecord` constructor introduced in #58, to improve maintainability by separating parsing CSV's values out from the Northstar and Rogue API requests executed in the `CreateRockTheVotePostInRogue` handler.

Does a bit of renaming to improve readability (it took me a long time to figure out what's going on in each):
* Renames `translateStatus` to `parseVoterRegistrationStatus`
* Renames `updateStatus` to `getVoterRegistrationStatusChange`

Also moves the logic for identifying test email addresses into an `is_valid_email` helper.

#### How should this be reviewed?

Verify import works as expected, no changes should have been made. 

#### Any background context you want to provide?

This adds a TODO cleanup -- after creating a new user, we make a 2nd request to update their `voter_registration_status`. This should be refactored to avoid making the second update request.


