### PR TITLE
Include action_id when importing RTV posts

### DIFF
--- a/app/Jobs/CreateRockTheVotePostInRogue.php
+++ b/app/Jobs/CreateRockTheVotePostInRogue.php
@@ -40,13 +40,15 @@ class RockTheVoteRecord {
         $this->voter_registration_status = Str::contains($rtvStatus, 'register') ? 'registration_complete' : $rtvStatus;
 
         $this->user_id = $this->parseUserId($record['Tracking Source']);
+
+        $postConfig = config('import.rock_the_vote.post');
        
-        $this->post_source = 'rock-the-vote';
+        $this->post_source = $postConfig['source'];
         $this->post_source_details = null;
         $this->post_details = $this->parsePostDetails($record);
         $this->post_status = $rtvStatus;
-        $this->post_type = 'voter-reg';
-        $this->post_action_id = config('import.rock_the_vote.action_id');
+        $this->post_type = $postConfig['type'];
+        $this->post_action_id =  $postConfig['action_id'];
     }
 
     /**

--- a/config/import.php
+++ b/config/import.php
@@ -1,7 +1,11 @@
 <?php
 
 return [
-  'rock_the_vote' => [
-    'action_id' =>  env('ROCK_THE_VOTE_ACTION_ID', 850),
-  ],
+    'rock_the_vote' => [
+        'post' => [
+            'action_id' => env('ROCK_THE_VOTE_POST_ACTION_ID', 850),
+            'type' => env('ROCK_THE_VOTE_POST_TYPE', 'voter-reg'),
+            'source' => env('ROCK_THE_VOTE_POST_SOURCE', 'rock-the-vote'),
+        ],
+    ],
 ];

--- a/config/import.php
+++ b/config/import.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+  'rock_the_vote' => [
+    'action_id' =>  env('ROCK_THE_VOTE_ACTION_ID', 850),
+  ],
+];


### PR DESCRIPTION
#### What's this PR do?

Completes TODO of passing an `action_id` parameter instead of `campaign_id`, and adds a `config/import` to define env variables per import type.

#### How should this be reviewed?

All posts imported from the RTV tab should be created with `action_id` 850 and source `rock-the-vote`.

#### Any background context you want to provide?

Unblocked by https://github.com/DoSomething/rogue/pull/837.

