### PR TITLE
Send password reset emails for new RTV users

### DIFF
--- a/app/Jobs/CreateRockTheVotePostInRogue.php
+++ b/app/Jobs/CreateRockTheVotePostInRogue.php
@@ -268,11 +268,11 @@ class CreateRockTheVotePostInRogue implements ShouldQueue
             $userData[$key] = $record->{$key};
         }
     
-        if (!empty($record->email_subscription_status)) {
+        if (isset($record->email_subscription_status)) {
             $userData['email_subscription_status'] = $record->email_subscription_status;
         }
 
-        if (!empty($record->sms_status)) {
+        if (isset($record->sms_status)) {
             $userData['sms_status'] = $record->sms_status;
         }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Str;
 /**
  * Returns whether email is a test email.
  * TODO: This isn't used anywhere, although deprecated jobs could use it to DRY. Remove it all?
+ * @see https://www.pivotaltracker.com/story/show/164114650
  *
  * @param string $email
  * @return boolean

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Str;
 
 /**
  * Returns whether email is a test email.
+ * TODO: This isn't used anywhere, although deprecated jobs could use it to DRY. Remove it all?
  *
  * @param string $email
  * @return boolean

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "aws/aws-sdk-php": "~3.0",
         "dfurnes/environmentalist": "0.0.2",
         "doctrine/dbal": "^2.6",
-        "dosomething/gateway": "^1.1.6",
+        "dosomething/gateway": "^1.17",
         "fideloper/proxy": "^4.0",
         "itsgoingd/clockwork": "^3.0",
         "laravel/framework": "5.6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad2a657a3c03af4f6feb7af42ac0c8a3",
+    "content-hash": "4eed7f556077c4f168660524c04dfd04",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -508,16 +508,16 @@
         },
         {
             "name": "dosomething/gateway",
-            "version": "v1.14.9",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DoSomething/gateway.git",
-                "reference": "15d3201b904d34d4220193938c0d4dce067f32dc"
+                "reference": "5a50114aadb40d00bc57885a66ec136091d85833"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/15d3201b904d34d4220193938c0d4dce067f32dc",
-                "reference": "15d3201b904d34d4220193938c0d4dce067f32dc",
+                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/5a50114aadb40d00bc57885a66ec136091d85833",
+                "reference": "5a50114aadb40d00bc57885a66ec136091d85833",
                 "shasum": ""
             },
             "require": {
@@ -565,7 +565,7 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2018-05-30T16:15:17+00:00"
+            "time": "2019-03-13T16:42:17+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",

--- a/config/import.php
+++ b/config/import.php
@@ -7,5 +7,8 @@ return [
             'type' => env('ROCK_THE_VOTE_POST_TYPE', 'voter-reg'),
             'source' => env('ROCK_THE_VOTE_POST_SOURCE', 'rock-the-vote'),
         ],
+        'reset' => [
+            'type' => env('ROCK_THE_VOTE_RESET_TYPE', 'rock-the-vote-activate-account'),
+        ],
     ],
 ];


### PR DESCRIPTION
#### What's this PR do?

* Sends an "Activate Account" email to new Rock The Vote users who have opted-in to email communication.

* Fixes setting Customer.io profile to `unsubscribed` if new user has not opt-ed in to email

* Modifies the RTV import to process all records, so we can test on QA.  I've modified our Call to Action Email event triggered campaign in Customer.io Staging to only send for users with `dosomething` domains, so we can test imports on QA without sending real emails to users.

#### How should this be reviewed?

While testing on Customer.io staging, confirm email is sent for new accounts with a `dosomething.org` domain, and email is not sent for non DS domains. I've been testing by uploading a CSV with my DS email and personal gmail, prefixed with `+[timestamp]`, e.g. `aschachter+201903121423@dosomething.org` so I can test that emails are sent.

For Customer.io production, emails will be sent for all new users (regardless of domain). We'll also need to modify some other event triggered campaigns in our production Customer.io instance per the [Deployment steps in our spec](https://docs.google.com/document/d/1RbWAAJA-zTfQYv6dBVIcpJqegKJUM0dH4DkVpikRpE0/edit?ts=5c6f0bd1#heading=h.f68k8ccmho5).

#### Any background context you want to provide?

* Merging this is blocked until we get final email copy added into Northstar for the `rock-the-vote-activate-account` password reset type.


