### PR TITLE
Config to disable sending RTV emails

### DIFF
--- a/config/import.php
+++ b/config/import.php
@@ -8,6 +8,7 @@ return [
             'source' => env('ROCK_THE_VOTE_POST_SOURCE', 'rock-the-vote'),
         ],
         'reset' => [
+            'enabled' => env('ROCK_THE_VOTE_RESET_ENABLED', 'true'),
             'type' => env('ROCK_THE_VOTE_RESET_TYPE', 'rock-the-vote-activate-account'),
         ],
     ],


### PR DESCRIPTION
#### What's this PR do?

Adds support for a `ROCK_THE_VOTE_RESET_ENABLED` environment variable to disable sending RTV Activate Account emails. There's still configuration work needed within the Customer.io UI to avoid sending double emails to new RTV users -- this config var allows us to toggle when to start sending `call_to_action_email` events with type `rock-the-vote-activate-account` in Customer.io.

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

Don't want to be blocked from deploying #65 to prod per pending Customer.io config changes.

