### PR TITLE
Display Rock The Vote config

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -29,7 +29,11 @@ class ImportController extends Controller
      */
     public function show()
     {
-        return view('pages.import');
+        return view('pages.import', [
+            'type' => request()->input('type'),
+            'postConfig' => config('import.rock_the_vote.post'),
+            'resetConfig' => config('import.rock_the_vote.reset'),
+        ]);
     }
 
     /**

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -13,19 +13,9 @@
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
-                    <li class="{{ request()->input('type') === \Chompy\ImportType::$turbovote ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type={{ \Chompy\ImportType::$turbovote }}">
-                            TurboVote
-                        </a>
-                    </li>
                     <li class="{{ request()->input('type') === \Chompy\ImportType::$rockTheVote ? 'active' : '' }}">
                         <a class="nav-item nav-link" href="/import?type={{ \Chompy\ImportType::$rockTheVote }}">
                             Rock The Vote
-                        </a>
-                    </li>
-                    <li class="{{ request()->input('type') === \Chompy\ImportType::$facebook ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type={{ \Chompy\ImportType::$facebook }}">
-                            Facebook Share
                         </a>
                     </li>
                     <li>

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -4,13 +4,18 @@
 
 @if (in_array(request()->input('type'), \Chompy\ImportType::all()))
     <div>
+        @if (request()->input('type') === \Chompy\ImportType::$rockTheVote)
+          <p>
+            Send Activate Account email: <strong>{{ config('import.rock_the_vote.reset.enabled') ? 'Enabled' : 'Disabled' }}</strong>
+          </p>
+        @endif
         <form action={{url('/import')}} method="post" enctype="multipart/form-data">
             {{ csrf_field() }}
             <div class="form-group">
                 <div class="input-group">
                     <label class="input-group-btn">
                         <span class="btn btn-default">
-                            Browse <input type="file" name="upload-file" style="display: none;" multiple>
+                            Select CSV <input type="file" name="upload-file" style="display: none;" multiple>
                         </span>
                     </label>
                     <input type="hidden" name="import-type" value={{ app('request')->input('type') }}>
@@ -18,7 +23,7 @@
                 </div>
             </div>
             <div>
-                <input type="submit" class="btn btn-primary" value="Submit CSV">
+                <input type="submit" class="btn btn-primary" value="Import">
             </div>
         </form>
     </div>

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -2,13 +2,22 @@
 
 @section('main_content')
 
-@if (in_array(request()->input('type'), \Chompy\ImportType::all()))
+@if ($type === \Chompy\ImportType::$rockTheVote)
     <div>
-        @if (request()->input('type') === \Chompy\ImportType::$rockTheVote)
-          <p>
-            Send Activate Account email: <strong>{{ config('import.rock_the_vote.reset.enabled') ? 'Enabled' : 'Disabled' }}</strong>
-          </p>
-        @endif
+        <h1>Rock The Vote</h1>
+        <p>Creates or updates users and posts from CSV.</p>
+        <h4>Users</h4>
+        <dl>
+            <dt>Source:</dt><dd>{{ config('services.northstar.client_credentials.client_id') }}</dd>
+            <dt>Reset email enabled</dt><dd>{{ $resetConfig['enabled'] ? 'true' : 'false'}}</dd>
+            <dt>Reset email type</dt><dd>{{ $resetConfig['type'] }}</dd>
+        </dl>
+        <h4>Posts</h4>
+        <dl>
+            <dt>Action ID</dt><dd>{{ $postConfig['action_id'] }}</dd>
+            <dt>Type</dt><dd>{{ $postConfig['type'] }}</dd>
+            <dt>Source</dt><dd>{{ $postConfig['source'] }}</dd>
+        </dl>
         <form action={{url('/import')}} method="post" enctype="multipart/form-data">
             {{ csrf_field() }}
             <div class="form-group">


### PR DESCRIPTION
#### What's this PR do?

Renders the variables in our Rock The Vote import config, to make it easy to determine whether the Send Email config introduced in #66 is enabled.

Also hides the import forms for jobs we no longer run (and plan to ✂️ from codebase in a subsequent PR for spring cleaning 🍃)

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

Beats checking the Heroku settings?

