### PR TITLE
Set email_subscription_topics for new users

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -33,6 +33,7 @@ class ImportController extends Controller
             'type' => request()->input('type'),
             'postConfig' => config('import.rock_the_vote.post'),
             'resetConfig' => config('import.rock_the_vote.reset'),
+            'userConfig' => config('import.rock_the_vote.user'),
         ]);
     }
 

--- a/app/Jobs/CreateRockTheVotePostInRogue.php
+++ b/app/Jobs/CreateRockTheVotePostInRogue.php
@@ -23,11 +23,14 @@ class RockTheVoteRecord {
         $this->first_name = $record['First name'];
         $this->last_name = $record['Last name'];
         $this->mobile = $record['Phone'];
-        $this->source = config('services.northstar.client_credentials.client_id');
+        $this->source = get_user_source();
 
         $emailOptIn = $record['Opt-in to Partner email?'];
         if ($emailOptIn) {
             $this->email_subscription_status = str_to_boolean($emailOptIn);
+            if ($this->email_subscription_status) {
+                $this->email_subscription_topics = explode(',', config('import.rock_the_vote.user.email_subscription_topics'));
+            }
         }
         // Note: Not a typo, this column name does not have the trailing question mark.
         $smsOptIn = $record['Opt-in to Partner SMS/robocall'];
@@ -272,6 +275,10 @@ class CreateRockTheVotePostInRogue implements ShouldQueue
     
         if (isset($record->email_subscription_status)) {
             $userData['email_subscription_status'] = $record->email_subscription_status;
+        }
+
+        if (isset($record->email_subscription_topics)) {
+            $userData['email_subscription_topics'] = $record->email_subscription_topics;
         }
 
         if (isset($record->sms_status)) {

--- a/app/Jobs/CreateRockTheVotePostInRogue.php
+++ b/app/Jobs/CreateRockTheVotePostInRogue.php
@@ -23,7 +23,6 @@ class RockTheVoteRecord {
         $this->first_name = $record['First name'];
         $this->last_name = $record['Last name'];
         $this->mobile = $record['Phone'];
-        $this->source = get_user_source();
 
         $emailOptIn = $record['Opt-in to Partner email?'];
         if ($emailOptIn) {
@@ -267,7 +266,7 @@ class CreateRockTheVotePostInRogue implements ShouldQueue
     {
         $userData = [];
 
-        $userFields = ['addr_city', 'addr_state', 'addr_street1', 'addr_street2', 'addr_zip', 'email', 'mobile', 'first_name', 'last_name', 'source', 'voter_registration_status'];
+        $userFields = ['addr_city', 'addr_state', 'addr_street1', 'addr_street2', 'addr_zip', 'email', 'mobile', 'first_name', 'last_name', 'voter_registration_status'];
 
         foreach ($userFields as $key) {
             $userData[$key] = $record->{$key};

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -31,3 +31,12 @@ function str_to_boolean($text)
 
     return filter_var($sanitized, FILTER_VALIDATE_BOOLEAN);
 }
+
+/**
+ * Returns source of a user created by import.
+ *
+ * @return string
+ */
+function get_user_source(){
+  return config('services.northstar.client_credentials.client_id');
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -31,12 +31,3 @@ function str_to_boolean($text)
 
     return filter_var($sanitized, FILTER_VALIDATE_BOOLEAN);
 }
-
-/**
- * Returns source of a user created by import.
- *
- * @return string
- */
-function get_user_source(){
-  return config('services.northstar.client_credentials.client_id');
-}

--- a/config/import.php
+++ b/config/import.php
@@ -11,5 +11,8 @@ return [
             'enabled' => env('ROCK_THE_VOTE_RESET_ENABLED', 'true'),
             'type' => env('ROCK_THE_VOTE_RESET_TYPE', 'rock-the-vote-activate-account'),
         ],
+        'user' => [
+            'email_subscription_topics' => env('ROCK_THE_VOTE_EMAIL_SUBSCRIPTION_TOPICS', 'community'),
+        ],
     ],
 ];

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -8,7 +8,6 @@
         <p>Creates/updates users and their voter registration post via CSV from Rock The Vote.</p>
         <h4>Users</h4>
         <dl class="dl-horizontal">
-            <dt>Source</dt><dd>{{ get_user_source() }}</dd>
             <dt>Email subscriptions</dt><dd>{{ $userConfig['email_subscription_topics'] }}</dd>
             <dt>Reset email enabled</dt><dd>{{ $resetConfig['enabled'] ? 'true' : 'false'}}</dd>
             <dt>Reset email type</dt><dd>{{ $resetConfig['type'] }}</dd>

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -5,16 +5,16 @@
 @if ($type === \Chompy\ImportType::$rockTheVote)
     <div>
         <h1>Rock The Vote</h1>
-        <p>Creates or updates users and their voter registration posts from CSV.</p>
+        <p>Creates/updates users and their voter registration post via CSV from Rock The Vote.</p>
         <h4>Users</h4>
-        <dl>
-            <dt>Source:</dt><dd>{{ get_user_source() }}</dd>
-            <dt>Email subscription topics:</dt><dd>{{ $userConfig['email_subscription_topics'] }}</dd>
+        <dl class="dl-horizontal">
+            <dt>Source</dt><dd>{{ get_user_source() }}</dd>
+            <dt>Email subscriptions</dt><dd>{{ $userConfig['email_subscription_topics'] }}</dd>
             <dt>Reset email enabled</dt><dd>{{ $resetConfig['enabled'] ? 'true' : 'false'}}</dd>
             <dt>Reset email type</dt><dd>{{ $resetConfig['type'] }}</dd>
         </dl>
         <h4>Posts</h4>
-        <dl>
+        <dl class="dl-horizontal">
             <dt>Action ID</dt><dd>{{ $postConfig['action_id'] }}</dd>
             <dt>Type</dt><dd>{{ $postConfig['type'] }}</dd>
             <dt>Source</dt><dd>{{ $postConfig['source'] }}</dd>

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -5,10 +5,11 @@
 @if ($type === \Chompy\ImportType::$rockTheVote)
     <div>
         <h1>Rock The Vote</h1>
-        <p>Creates or updates users and posts from CSV.</p>
+        <p>Creates or updates users and their voter registration posts from CSV.</p>
         <h4>Users</h4>
         <dl>
-            <dt>Source:</dt><dd>{{ config('services.northstar.client_credentials.client_id') }}</dd>
+            <dt>Source:</dt><dd>{{ get_user_source() }}</dd>
+            <dt>Email subscription topics:</dt><dd>{{ $userConfig['email_subscription_topics'] }}</dd>
             <dt>Reset email enabled</dt><dd>{{ $resetConfig['enabled'] ? 'true' : 'false'}}</dd>
             <dt>Reset email type</dt><dd>{{ $resetConfig['type'] }}</dd>
         </dl>


### PR DESCRIPTION
#### What's this PR do?

* Subscribes new users to the community newsletter per https://www.pivotaltracker.com/n/projects/2019429. Refs https://github.com/DoSomething/northstar/pull/851 (renaming `action` to `community`)

* Adds a `get_user_source` helper to DRY setting a new user.source across all import jobs (refs #64)

#### How should this be reviewed?

Verify new users have `email_subscription_status` set to `['community']`

#### Any background context you want to provide?

Feeling just about ready to  ✂️🔥 the import jobs we no longer use (TurboVote, FB Share) for epic spring cleaning 🍃 

#### Relevant tickets

Fixes https://www.pivotaltracker.com/n/projects/2019429
