### PR TITLE
Removes check to see if a post exists and adds logging 

### DIFF
--- a/app/Jobs/CreateCallPowerPostInRogue.php
+++ b/app/Jobs/CreateCallPowerPostInRogue.php
@@ -43,9 +43,9 @@ class CreateCallPowerPostInRogue implements ShouldQueue
         // Using the callpower_campaign_id, get the action id from Rogue.
         $actionId = $rogue->getActionIdFromCallPowerCampaignId($this->parameters['callpower_campaign_id']);
 
-        info('creating post in rogue for northstar user: ' . $user->id);
-
         $details = $this->extractDetails($this->parameters);
+
+        info('creating post in rogue for northstar user: ' . $user->id . ' and details: ' . $details);
 
         // Determine source details.
         $post = $rogue->createPost([

--- a/app/Jobs/CreateCallPowerPostInRogue.php
+++ b/app/Jobs/CreateCallPowerPostInRogue.php
@@ -43,32 +43,24 @@ class CreateCallPowerPostInRogue implements ShouldQueue
         // Using the callpower_campaign_id, get the action id from Rogue.
         $actionId = $rogue->getActionIdFromCallPowerCampaignId($this->parameters['callpower_campaign_id']);
 
-        // Check if the post exists in Rogue. If not, create the post.
-        $existingPost = $rogue->getPost([
-          'action_id' => $actionId,
-          'northstar_id' => $user->id,
+        info('creating post in rogue for northstar user: ' . $user->id);
+
+        $details = $this->extractDetails($this->parameters);
+
+        // Determine source details.
+        $post = $rogue->createPost([
+            'northstar_id' => $user->id,
+            'action_id' => $actionId,
+            'type' => 'phone-call',
+            'status' => $this->parameters['status'] === 'completed' ? 'accepted' : 'incomplete',
+            'quantity' => 1,
+            'source_details' => 'CallPower',
+            'details' => $details,
+            'dont_send_to_blink' => true,
         ]);
 
-        if (! $existingPost['data']) {
-            info('creating post in rogue for northstar user: ' . $user->id);
-
-            $details = $this->extractDetails($this->parameters);
-
-            // Determine source details.
-            $post = $rogue->createPost([
-                'northstar_id' => $user->id,
-                'action_id' => $actionId,
-                'type' => 'phone-call',
-                'status' => $this->parameters['status'] === 'completed' ? 'accepted' : 'incomplete',
-                'quantity' => 1,
-                'source_details' => 'CallPower',
-                'details' => $details,
-                'dont_send_to_blink' => true,
-            ]);
-
-            if ($post['data']) {
-                info('post created in rogue for northstar user: ' . $user->id);
-            }
+        if ($post['data']) {
+            info('post created in rogue for northstar user: ' . $user->id);
         }
     }
 

--- a/app/Services/Rogue.php
+++ b/app/Services/Rogue.php
@@ -111,6 +111,7 @@ class Rogue extends RestApiClient
         ]);
 
         if (! $action['data'][0]['id']) {
+            info('action id not found for CallPower campaign id: ' . $callpowerCampaignId);
             throw new Exception(500, 'Unable to get action data for CallPower campaign id : ' . $callpowerCampaignId);
         }
 

--- a/tests/Http/CallPowerTest.php
+++ b/tests/Http/CallPowerTest.php
@@ -1,0 +1,1 @@
+CallPowerTest.php

--- a/tests/Http/CallPowerTest.php
+++ b/tests/Http/CallPowerTest.php
@@ -1,1 +1,0 @@
-CallPowerTest.php


### PR DESCRIPTION
#### What's this PR do?
- Removes check to see if a post exists in Rogue (dupes will be on the data reporting side, see convo [here](https://dosomething.slack.com/archives/C2BLZGBPH/p1553524974012200)).
- Adds logging if an action doesn't exist for a CallPower campaign id.

#### How should this be reviewed?
👀 

#### Relevant tickets

Fixes some code from #64 
