### PR TITLE
Refactor import type as route parameter instead of query parameter

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -27,7 +27,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/';
+    protected $redirectTo = '/import/rock-the-vote';
 
     /**
      * Where to redirect users after logout.

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -31,12 +31,9 @@ class ImportController extends Controller
      */
     public function show($importType)
     {
-        $vars = ImportType::getVars($importType);
-
         return view('pages.import', [
-            'title' => $vars['title'],
             'type' => $importType,
-            'config' => $vars['config'],
+            'config' => ImportType::getConfig($importType),
         ]);
     }
 

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -26,21 +26,25 @@ class ImportController extends Controller
 
     /*
      * Show the upload form.
+     *
+     * @param string $importType
      */
     public function show($importType)
     {
+        $vars = ImportType::getVars($importType);
+
         return view('pages.import', [
+            'title' => $vars['title'],
             'type' => $importType,
-            'postConfig' => config('import.rock_the_vote.post'),
-            'resetConfig' => config('import.rock_the_vote.reset'),
-            'userConfig' => config('import.rock_the_vote.user'),
+            'config' => $vars['config'],
         ]);
     }
 
     /**
      * Import the uploaded file.
      *
-     * @param  Request $request
+     * @param Request $request
+     * @param string $importType
      */
     public function store(Request $request, $importType)
     {
@@ -74,7 +78,7 @@ class ImportController extends Controller
             ImportFacebookSharePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        return redirect()->route('import/'.$importType)
+        return redirect('import/'.$importType)
             ->with('status', 'Your CSV was added to the queue to be processed.');
     }
 }

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -27,10 +27,10 @@ class ImportController extends Controller
     /*
      * Show the upload form.
      */
-    public function show()
+    public function show($importType)
     {
         return view('pages.import', [
-            'type' => request()->input('type'),
+            'type' => $importType,
             'postConfig' => config('import.rock_the_vote.post'),
             'resetConfig' => config('import.rock_the_vote.reset'),
             'userConfig' => config('import.rock_the_vote.user'),
@@ -42,17 +42,16 @@ class ImportController extends Controller
      *
      * @param  Request $request
      */
-    public function store(Request $request)
+    public function store(Request $request, $importType)
     {
         $request->validate([
             'upload-file' => 'required|mimes:csv,txt',
-            'import-type' => 'required',
         ]);
 
         // Push file to S3.
         $upload = $request->file('upload-file');
 
-        $path = 'uploads/' . $request->input('import-type') . '-importer' . Carbon::now() . '.csv';
+        $path = 'uploads/' . $importType . '-importer' . Carbon::now() . '.csv';
         $csv = Reader::createFromPath($upload->getRealPath());
         $success = Storage::put($path, (string) $csv);
 
@@ -60,23 +59,22 @@ class ImportController extends Controller
             throw new HttpException(500, 'Unable read and store file to S3.');
         }
 
-        $type = $request->input('import-type');
-
-        if ($type === ImportType::$turbovote) {
+        if ($importType === ImportType::$turbovote) {
             info('turbo vote import happening');
             ImportTurboVotePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        if ($type === ImportType::$rockTheVote) {
+        if ($importType === ImportType::$rockTheVote) {
             info('rock the vote import happening');
             ImportRockTheVotePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        if ($type === ImportType::$facebook) {
+        if ($importType === ImportType::$facebook) {
             info('Facebook share import happening');
             ImportFacebookSharePosts::dispatch($path)->delay(now()->addSeconds(3));
         }
 
-        return redirect()->route('import.show', ['type' => $type])->with('status', 'Your CSV was added to the queue to be processed.');
+        return redirect()->route('import/'.$importType)
+            ->with('status', 'Your CSV was added to the queue to be processed.');
     }
 }

--- a/app/ImportType.php
+++ b/app/ImportType.php
@@ -34,4 +34,21 @@ class ImportType
     {
         return [self::$facebook, self::$rockTheVote, self::$turbovote];
     }
+
+    /**
+     * Returns config array of given import type.
+     *
+     * @return array
+     */
+    public static function getVars($type)
+    {
+        if ($type === self::$rockTheVote) {
+            return [
+                'title' => 'Rock The Vote',
+                'config' => config('import.rock_the_vote'),
+            ];
+        }
+
+        throw new HttpException(500, 'Config not found for type '.$type.'.');
+    }
 }

--- a/app/ImportType.php
+++ b/app/ImportType.php
@@ -40,13 +40,10 @@ class ImportType
      *
      * @return array
      */
-    public static function getVars($type)
+    public static function getConfig($type)
     {
         if ($type === self::$rockTheVote) {
-            return [
-                'title' => 'Rock The Vote',
-                'config' => config('import.rock_the_vote'),
-            ];
+            return config('import.rock_the_vote');
         }
 
         throw new HttpException(500, 'Config not found for type '.$type.'.');

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -13,7 +13,7 @@
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
-                    <li class="{{ request()->input('type') === \Chompy\ImportType::$rockTheVote ? 'active' : '' }}">
+                    <li class="{{ request()->url('') === 'import/'.\Chompy\ImportType::$rockTheVote ? 'active' : '' }}">
                         <a class="nav-item nav-link" href="/import?type={{ \Chompy\ImportType::$rockTheVote }}">
                             Rock The Vote
                         </a>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -8,13 +8,13 @@
                 <span class="icon-bar"></span>
             </button>
 
-            <a class="navbar-brand" href="/">Chompy</a>
+            <a class="navbar-brand">Chompy</a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
-                    <li class="{{ request()->url('') === 'import/'.\Chompy\ImportType::$rockTheVote ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="/import?type={{ \Chompy\ImportType::$rockTheVote }}">
+                    <li class="{{ str_contains(request()->url(), $rockTheVote) ? 'active' : '' }}">
+                        <a class="nav-item nav-link" href="{{ $rockTheVote  }}">
                             Rock The Vote
                         </a>
                     </li>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -29,7 +29,9 @@
             </div>
         @endif
         <div class="container">
-            @include('components.nav')
+            @include('components.nav', [
+                'rockTheVote' => '/import/'.\Chompy\ImportType::$rockTheVote,
+            ])
         </div>
 
         <div class="container">

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -3,7 +3,6 @@
 @section('main_content')
 
 <div>
-    <h1>{{ $title }}</h1>
     @if ($type === \Chompy\ImportType::$rockTheVote)
     @include('pages.partials.rock-the-vote', ['config' => $config])
     @endif

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -18,7 +18,7 @@
             <dt>Type</dt><dd>{{ $postConfig['type'] }}</dd>
             <dt>Source</dt><dd>{{ $postConfig['source'] }}</dd>
         </dl>
-        <form action={{url('/import')}} method="post" enctype="multipart/form-data">
+        <form action={{ app('request')->url() }} method="post" enctype="multipart/form-data">
             {{ csrf_field() }}
             <div class="form-group">
                 <div class="input-group">
@@ -27,7 +27,6 @@
                             Select CSV <input type="file" name="upload-file" style="display: none;" multiple>
                         </span>
                     </label>
-                    <input type="hidden" name="import-type" value={{ app('request')->input('type') }}>
                     <input type="text" class="form-control" readonly>
                 </div>
             </div>

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -2,46 +2,35 @@
 
 @section('main_content')
 
-@if ($type === \Chompy\ImportType::$rockTheVote)
-    <div>
-        <h1>Rock The Vote</h1>
-        <p>Creates/updates users and their voter registration post via CSV from Rock The Vote.</p>
-        <h4>Users</h4>
-        <dl class="dl-horizontal">
-            <dt>Email subscriptions</dt><dd>{{ $userConfig['email_subscription_topics'] }}</dd>
-            <dt>Reset email enabled</dt><dd>{{ $resetConfig['enabled'] ? 'true' : 'false'}}</dd>
-            <dt>Reset email type</dt><dd>{{ $resetConfig['type'] }}</dd>
-        </dl>
-        <h4>Posts</h4>
-        <dl class="dl-horizontal">
-            <dt>Action ID</dt><dd>{{ $postConfig['action_id'] }}</dd>
-            <dt>Type</dt><dd>{{ $postConfig['type'] }}</dd>
-            <dt>Source</dt><dd>{{ $postConfig['source'] }}</dd>
-        </dl>
-        <form action={{ app('request')->url() }} method="post" enctype="multipart/form-data">
-            {{ csrf_field() }}
-            <div class="form-group">
-                <div class="input-group">
-                    <label class="input-group-btn">
-                        <span class="btn btn-default">
-                            Select CSV <input type="file" name="upload-file" style="display: none;" multiple>
-                        </span>
-                    </label>
-                    <input type="text" class="form-control" readonly>
-                </div>
+<div>
+    <h1>{{ $title }}</h1>
+    @if ($type === \Chompy\ImportType::$rockTheVote)
+    @include('pages.partials.rock-the-vote', ['config' => $config])
+    @endif
+    <form action={{ app('request')->url() }} method="post" enctype="multipart/form-data">
+        {{ csrf_field() }}
+        <div class="form-group">
+            <div class="input-group">
+                <label class="input-group-btn">
+                    <span class="btn btn-default">
+                        Select CSV <input type="file" name="upload-file" style="display: none;" multiple>
+                    </span>
+                </label>
+                <input type="text" class="form-control" readonly>
             </div>
-            <div>
-                <input type="submit" class="btn btn-primary" value="Import">
-            </div>
-        </form>
-    </div>
-    <h2>Progress Log</h2>
-    <div id="messages">
-        <!--Messages goes here-->
-    </div>
-    <div class="progress">
-        <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div>
-    </div>
-@endif
+        </div>
+        <div>
+            <input type="submit" class="btn btn-primary" value="Import">
+        </div>
+    </form>
+</div>
+<h2>Progress Log</h2>
+<div id="messages">
+    <!--Messages goes here-->
+</div>
+<div class="progress">
+    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div>
+</div>
+
 
 @endsection

--- a/resources/views/pages/partials/rock-the-vote.blade.php
+++ b/resources/views/pages/partials/rock-the-vote.blade.php
@@ -1,0 +1,15 @@
+<div>
+    <p>Creates/updates users and their voter registration post via CSV from Rock The Vote.</p>
+    <h4>Users</h4>
+    <dl class="dl-horizontal">
+        <dt>Email subscriptions</dt><dd>{{ $config['user']['email_subscription_topics'] }}</dd>
+        <dt>Reset email enabled</dt><dd>{{ $config['reset']['enabled'] ? 'true' : 'false'}}</dd>
+        <dt>Reset email type</dt><dd>{{ $config['reset']['type'] }}</dd>
+    </dl>
+    <h4>Posts</h4>
+    <dl class="dl-horizontal">
+        <dt>Action ID</dt><dd>{{ $config['post']['action_id'] }}</dd>
+        <dt>Type</dt><dd>{{ $config['post']['type'] }}</dd>
+        <dt>Source</dt><dd>{{ $config['post']['source'] }}</dd>
+    </dl>
+</div>

--- a/resources/views/pages/partials/rock-the-vote.blade.php
+++ b/resources/views/pages/partials/rock-the-vote.blade.php
@@ -1,4 +1,5 @@
 <div>
+    <h1>Rock The Vote</h1>
     <p>Creates/updates users and their voter registration post via CSV from Rock The Vote.</p>
     <h4>Users</h4>
     <dl class="dl-horizontal">

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,8 +11,8 @@
 |
 */
 
-$router->get('/import', 'ImportController@show')->name('import.show');
-$router->post('import', 'ImportController@store')->name('import.store');
+$router->get('import/{importType}', 'ImportController@show')->name('import.show');
+$router->post('import/{importType}', 'ImportController@store')->name('import.store');
 
 Route::get('/', function () {
     return view('pages.home');


### PR DESCRIPTION
#### What's this PR do?

* Changes import by csv route from `import?type=:type` to `import/:type`, to DRY requesting the `type` query parameter throughout the codebase

* Cleans up the `ImportController`:  The changes #67 hardcoded the `show` method to display RTV config, which is fine as we're no longer using/supporting the Turbovote or Facebook Share types, but this PR will make it easier to add more upload CSV forms, should we ever need them

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

Next up, removing deprecated code / import types? 🔪 🍖 🍽 

#### Relevant tickets

https://www.pivotaltracker.com/story/show/164114650
