### PR TITLE
Rock The Vote import cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,25 @@ IMPORTER_API_KEY=
 
 # Storage Driver
 FILESYSTEM_DRIVER=local
+
+##
+## Optional config overrides - Rock The Vote Import
+##
+
+# The action id to get/create a post for.
+ROCK_THE_VOTE_POST_ACTION_ID=850
+
+# The post type to get/create a post for.
+ROCK_THE_VOTE_POST_ACTION_TYPE=voter-reg
+
+# The post source.
+ROCK_THE_VOTE_POST_SOURCE=rock-the-vote
+
+# Comma separated list of the email subscription topics to save for new users
+ROCK_THE_VOTE_EMAIL_SUBSCRIPTION_TOPICS=community,scholarships
+
+# Password reset type to send, should be valid per https://github.com/DoSomething/northstar/blob/master/documentation/endpoints/resets.md#send-a-password-reset-email
+ROCK_THE_VOTE_RESET_TYPE=rock-the-vote-activate-account
+
+# Set to 'false' to disable posting to Northstar Resets endpoint to sending email.
+ROCK_THE_VOTE_RESET_ENABLED=true

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -32,7 +32,7 @@ class ImportController extends Controller
     public function show($importType)
     {
         return view('pages.import', [
-            'type' => $importType,
+            'importType' => $importType,
             'config' => ImportType::getConfig($importType),
         ]);
     }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -2037,8 +2037,6 @@ pre code {
 .container-fluid {
   margin-right: auto;
   margin-left: auto;
-  padding-left: 15px;
-  padding-right: 15px;
 }
 
 .container-fluid:before,
@@ -5281,12 +5279,6 @@ tbody.collapse.in {
   clear: both;
 }
 
-@media (min-width: 768px) {
-  .navbar {
-    border-radius: 4px;
-  }
-}
-
 .navbar-header:before,
 .navbar-header:after {
   content: " ";
@@ -5364,14 +5356,6 @@ tbody.collapse.in {
   .navbar-fixed-bottom .navbar-collapse {
     max-height: 200px;
   }
-}
-
-.container > .navbar-header,
-.container > .navbar-collapse,
-.container-fluid > .navbar-header,
-.container-fluid > .navbar-collapse {
-  margin-right: -15px;
-  margin-left: -15px;
 }
 
 @media (min-width: 768px) {

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-default">
-    <div class="container-fluid">
+    <div class="container">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
                 <span class="sr-only">Toggle navigation</span>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -13,7 +13,7 @@
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
-                    <li class="{{ str_contains(request()->url(), $rockTheVote) ? 'active' : '' }}">
+                    <li class="{{ request()->is('import/' . $rockTheVote) ? 'active' : '' }}">
                         <a class="nav-item nav-link" href="{{ $rockTheVote  }}">
                             Rock The Vote
                         </a>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -13,8 +13,8 @@
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
-                    <li class="{{ request()->is('import/' . $rockTheVote) ? 'active' : '' }}">
-                        <a class="nav-item nav-link" href="{{ $rockTheVote  }}">
+                    <li class="{{ Request::path() === $rockTheVotePath ? 'active' : '' }}">
+                        <a class="nav-item nav-link" href="{{  '/'.$rockTheVotePath }}">
                             Rock The Vote
                         </a>
                     </li>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -28,7 +28,7 @@
                 </ul>
             </div>
         @endif
-        <div class="container">
+        <div class="container-fluid">
             @include('components.nav', [
                 'rockTheVotePath' => 'import/'.\Chompy\ImportType::$rockTheVote,
             ])

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -30,7 +30,7 @@
         @endif
         <div class="container">
             @include('components.nav', [
-                'rockTheVote' => '/import/'.\Chompy\ImportType::$rockTheVote,
+                'rockTheVotePath' => 'import/'.\Chompy\ImportType::$rockTheVote,
             ])
         </div>
 

--- a/resources/views/pages/import.blade.php
+++ b/resources/views/pages/import.blade.php
@@ -3,10 +3,10 @@
 @section('main_content')
 
 <div>
-    @if ($type === \Chompy\ImportType::$rockTheVote)
+    @if ($importType === \Chompy\ImportType::$rockTheVote)
     @include('pages.partials.rock-the-vote', ['config' => $config])
     @endif
-    <form action={{ app('request')->url() }} method="post" enctype="multipart/form-data">
+    <form action={{ route('import.store', ['importType' => $importType]) }} method="post" enctype="multipart/form-data">
         {{ csrf_field() }}
         <div class="form-group">
             <div class="input-group">


### PR DESCRIPTION
#### What's this PR do?

* Adds changes per #72 review
* Calls `getConfig` introduced in #72 to DRY 
* Updates `.env.example` example RTV config overrides
* Brazenly adds unasked-for style changes to expand navbar across the full screen width, which soothes my soul -- I hope this potentially does the same for others

<img width="1434" alt="Screen Shot 2019-03-26 at 9 14 33 PM" src="https://user-images.githubusercontent.com/1236811/55050102-345f4800-500c-11e9-8531-ab32e9faa7b6.png">

#### How should this be reviewed?

🌴 