### PR TITLE
Makes campaign_target_district optional

### DIFF
--- a/app/Http/Controllers/ThirdParty/CallPowerController.php
+++ b/app/Http/Controllers/ThirdParty/CallPowerController.php
@@ -30,7 +30,7 @@ class CallPowerController extends Controller
             'call_duration' => 'required|integer',
             'campaign_target_name' => 'required|string',
             'campaign_target_title' => 'required|string',
-            'campaign_target_district' => 'required|string',
+            'campaign_target_district' => 'string',
             'callpower_campaign_name' => 'required|string',
             'number_dialed_into' => 'required',
         ]);

--- a/docs/endpoints/callpower.md
+++ b/docs/endpoints/callpower.md
@@ -20,7 +20,7 @@ POST /api/v1/callpower/call
   The name of the target the user called.
 - **campaign_target_title** (string) required.
   The title of the target the user called.
-- **campaign_target_district** (string) required.
+- **campaign_target_district** (string)
   The district of the target the user called.
 - **callpower_campaign_name** (string) required.
   The CallPower campaign name given in CallPower.


### PR DESCRIPTION
#### What's this PR do?
- Makes `campaign_target_district` optional. Josh mentioned that some targets don't have a district or are custom so we should have this as an optional field. 
- Updates documentation. 

#### How should this be reviewed?
👀 
