### PR TITLE
makes campaign_target_district nullable

### DIFF
--- a/app/Http/Controllers/ThirdParty/CallPowerController.php
+++ b/app/Http/Controllers/ThirdParty/CallPowerController.php
@@ -30,7 +30,7 @@ class CallPowerController extends Controller
             'call_duration' => 'required|integer',
             'campaign_target_name' => 'required|string',
             'campaign_target_title' => 'required|string',
-            'campaign_target_district' => 'string',
+            'campaign_target_district' => 'nullable|string',
             'callpower_campaign_name' => 'required|string',
             'number_dialed_into' => 'required',
         ]);


### PR DESCRIPTION
#### What's this PR do?
Makes `campaign_target_district` `nullable` so it doesn't throw an error if `null` is sent. 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
https://laravel.com/docs/5.8/validation#a-note-on-optional-fields

#### Relevant tickets

Fixes #77 
