### PR TITLE
Fixes failed migration added in #82

### DIFF
--- a/database/migrations/2019_04_01_000000_drop_password_resets_and_stats_tables.php
+++ b/database/migrations/2019_04_01_000000_drop_password_resets_and_stats_tables.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Migrations\Migration;
 
-class RemovePasswordResetsAndStatsTables extends Migration
+class DropPasswordResetsAndStatsTables extends Migration
 {
     /**
      * Run the migrations.


### PR DESCRIPTION
#### What's this PR do?

Changes the class name to match file name to fix the `Class 'DropPasswordResetsAndStatsTables' not found` error per https://github.com/DoSomething/chompy/pull/82#issuecomment-479201640

#### How should this be reviewed?

I deleted all tables in my DB, ran `php artisan migrate`, and don't see signs of the `password_resets` or `stats` tables that #82 meant to drop

#### Any background context you want to provide?
🔥 

