### PR TITLE
adds logging before sending job to create CallPower post and after job is sent

### DIFF
--- a/app/Http/Controllers/ThirdParty/CallPowerController.php
+++ b/app/Http/Controllers/ThirdParty/CallPowerController.php
@@ -3,7 +3,6 @@
 namespace Chompy\Http\Controllers\ThirdParty;
 
 use Illuminate\Http\Request;
-use Illuminate\Log\LogManager;
 use Chompy\Http\Controllers\Controller;
 use Chompy\Jobs\CreateCallPowerPostInRogue;
 

--- a/app/Http/Controllers/ThirdParty/CallPowerController.php
+++ b/app/Http/Controllers/ThirdParty/CallPowerController.php
@@ -3,6 +3,7 @@
 namespace Chompy\Http\Controllers\ThirdParty;
 
 use Illuminate\Http\Request;
+use Illuminate\Log\LogManager;
 use Chompy\Http\Controllers\Controller;
 use Chompy\Jobs\CreateCallPowerPostInRogue;
 
@@ -35,7 +36,21 @@ class CallPowerController extends Controller
             'number_dialed_into' => 'required',
         ]);
 
+        Log::debug('sending job to create post with details: ' . json_encode([
+                'mobile' => $request['mobile'],
+                'callpower_campaign_id' => $request['callpower_campaign_id'],
+                'status' => $request['status'],
+            ])
+        );
+
         // Send to queued job.
         CreateCallPowerPostInRogue::dispatch($parameters);
+
+        Log::debug('sent job to create post with details: ' . json_encode([
+                'mobile' => $request['mobile'],
+                'callpower_campaign_id' => $request['callpower_campaign_id'],
+                'status' => $request['status'],
+            ])
+        );
     }
 }

--- a/app/Http/Controllers/ThirdParty/CallPowerController.php
+++ b/app/Http/Controllers/ThirdParty/CallPowerController.php
@@ -44,12 +44,5 @@ class CallPowerController extends Controller
 
         // Send to queued job.
         CreateCallPowerPostInRogue::dispatch($parameters);
-
-        Log::debug('sent job to create post with details: ' . json_encode([
-                'mobile' => $request['mobile'],
-                'callpower_campaign_id' => $request['callpower_campaign_id'],
-                'status' => $request['status'],
-            ])
-        );
     }
 }


### PR DESCRIPTION
#### What's this PR do?
Adds logging before sending job to create CallPower post and after job is sent. 

#### How should this be reviewed?
Is this enough logging for us to see where the slow down is? Any other places I should put logs to help debug? 

#### Any background context you want to provide?
CallPower sent us historical records for our systems to ingest into Rogue. At first, they all ended up in the `failed_jobs` table because there were no action ids for these campaigns in Rogue. When we re-tried the jobs, they started making it into the Rogue QA database (!) however, the queue was working very slowly (we kicked off the retry job on Tuesday and it wasn't done until Friday, with less than 4k records). We hope these logs will help debug why the queue was going so slowly.

