### PR TITLE
adds use use Illuminate\Support\Facades\Log; to CallPowerController

### DIFF
--- a/app/Http/Controllers/ThirdParty/CallPowerController.php
+++ b/app/Http/Controllers/ThirdParty/CallPowerController.php
@@ -3,6 +3,7 @@
 namespace Chompy\Http\Controllers\ThirdParty;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Chompy\Http\Controllers\Controller;
 use Chompy\Jobs\CreateCallPowerPostInRogue;
 


### PR DESCRIPTION
#### What's this PR do?
adds use use Illuminate\Support\Facades\Log; to CallPowerController in order to use logging in that file. 

#### How should this be reviewed?
👀 

#### Relevant tickets

Fixes mistake in #88 
