### PR TITLE
Removes requirement for campaign_target_title and campaign_target_district

### DIFF
--- a/app/Http/Controllers/ThirdParty/SoftEdgeController.php
+++ b/app/Http/Controllers/ThirdParty/SoftEdgeController.php
@@ -29,8 +29,8 @@ class SoftEdgeController extends Controller
             'action_id' => 'required|integer',
             'email_timestamp' => 'required|date',
             'campaign_target_name' => 'required|string',
-            'campaign_target_title' => 'required|string',
-            'campaign_target_district' => 'nullable|string',
+            'campaign_target_title' => 'string',
+            'campaign_target_district' => 'string',
         ]);
 
         Log::debug('sending job to create post with details', [

--- a/app/Http/Controllers/ThirdParty/SoftEdgeController.php
+++ b/app/Http/Controllers/ThirdParty/SoftEdgeController.php
@@ -29,8 +29,8 @@ class SoftEdgeController extends Controller
             'action_id' => 'required|integer',
             'email_timestamp' => 'required|date',
             'campaign_target_name' => 'required|string',
-            'campaign_target_title' => 'string',
-            'campaign_target_district' => 'string',
+            'campaign_target_title' => 'nullable|string',
+            'campaign_target_district' => 'nullable|string',
         ]);
 
         Log::debug('sending job to create post with details', [


### PR DESCRIPTION
#### What's this PR do?
This PR removes requirement for `campaign_target_title` and `campaign_target_district`. If we would like for a user to send to a custom person (e.g. letter to the editor), these fields will be left blank when sent to our system so we will need to remove these as required fields. 

#### How should this be reviewed?
👀 

#### Relevant tickets
[Pivotal Card
](https://www.pivotaltracker.com/n/projects/2019313/stories/165974086)