### PR TITLE
if title and district are not set, set to null

### DIFF
--- a/app/Jobs/CreateSoftEdgePostInRogue.php
+++ b/app/Jobs/CreateSoftEdgePostInRogue.php
@@ -70,8 +70,8 @@ class CreateSoftEdgePostInRogue implements ShouldQueue
         return json_encode([
             'email_timestamp' => $email['email_timestamp'],
             'campaign_target_name' => $email['campaign_target_name'],
-            'campaign_target_title' => $email['campaign_target_title'],
-            'campaign_target_district' => $email['campaign_target_district'],
+            'campaign_target_title' => $email['campaign_target_title'] ? $email['campaign_target_title'] : null,
+            'campaign_target_district' => $email['campaign_target_district'] ? $email['campaign_target_district'] : null,
         ]);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This PR sets `campaign_target_title` and `campaign_target_district` to `null` if they are not sent in the request. 

#### How should this be reviewed?
👀 

#### Relevant tickets

Fixes needed work for #94 
