### PR TITLE
Send password reset emails when importing news email subscriptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,16 @@ SOFTEDGE_API_KEY=
 FILESYSTEM_DRIVER=local
 
 ##
+## Optional config overrides - Email Subscription Import
+##
+
+# Set to 'false' to disable posting to Northstar Resets endpoint to sending email for new users that subscribe to the news topic.
+NEWS_SUBSCRIPTION_RESET_ENABLED=true
+
+# Password reset type to send to new users that subscribe to the news topic, should be valid per https://github.com/DoSomething/northstar/blob/master/documentation/endpoints/resets.md#send-a-password-reset-email
+NEWS_SUBSCRIPTION_RESET_TYPE=breakdown-activate-account
+
+##
 ## Optional config overrides - Rock The Vote Import
 ##
 

--- a/.env.example
+++ b/.env.example
@@ -67,10 +67,10 @@ FILESYSTEM_DRIVER=local
 ## Optional config overrides - Email Subscription Import
 ##
 
-# Set to 'false' to disable posting to Northstar Resets endpoint to sending email for new users that subscribe to the news topic.
+# Set to 'false' to disable posting to Northstar Resets endpoint to send password reset email for new users that subscribe to the news topic.
 NEWS_SUBSCRIPTION_RESET_ENABLED=true
 
-# Password reset type to send to new users that subscribe to the news topic, should be valid per https://github.com/DoSomething/northstar/blob/master/documentation/endpoints/resets.md#send-a-password-reset-email
+# Password reset email type to send to new users that subscribe to the news topic, should be valid per https://github.com/DoSomething/northstar/blob/master/documentation/endpoints/resets.md#send-a-password-reset-email
 NEWS_SUBSCRIPTION_RESET_TYPE=breakdown-activate-account
 
 ##
@@ -89,8 +89,8 @@ ROCK_THE_VOTE_POST_SOURCE=rock-the-vote
 # Comma separated list of the email subscription topics to save for new users
 ROCK_THE_VOTE_EMAIL_SUBSCRIPTION_TOPICS=community,scholarships
 
-# Password reset type to send, should be valid per https://github.com/DoSomething/northstar/blob/master/documentation/endpoints/resets.md#send-a-password-reset-email
+# Password reset email type to send, should be valid per https://github.com/DoSomething/northstar/blob/master/documentation/endpoints/resets.md#send-a-password-reset-email
 ROCK_THE_VOTE_RESET_TYPE=rock-the-vote-activate-account
 
-# Set to 'false' to disable posting to Northstar Resets endpoint to sending email.
+# Set to 'false' to disable posting to Northstar Resets endpoint to send password reset email.
 ROCK_THE_VOTE_RESET_ENABLED=true

--- a/app/Jobs/ImportEmailSubscription.php
+++ b/app/Jobs/ImportEmailSubscription.php
@@ -135,18 +135,23 @@ class ImportEmailSubscription implements ShouldQueue
      */
     private function sendUserPasswordReset($user)
     {
+        $logParams = ['user' => $user->id];
         $newsTopic = 'news';
+
         if (! in_array($newsTopic, $user->email_subscription_topics)) {
+            info('New user is not subscribed to news, no email sent.', $logParams);
+
             return;
         }
 
         $config = ImportType::getConfig(ImportType::$emailSubscription);
         $newsTopicResetConfig = $config['topics'][$newsTopic]['reset'];
         $resetType = $newsTopicResetConfig['type'];
-        $logParams = ['user' => $user->id, 'type' => $resetType];
+        $logParams['type'] = $resetType;
 
         if ($newsTopicResetConfig['enabled'] !== 'true') {
             info('Reset email is disabled. Would have sent reset email', $logParams);
+
             return;
         }
 

--- a/config/import.php
+++ b/config/import.php
@@ -2,7 +2,17 @@
 
 return [
     'email_subscription' => [
-        'topics' => ['community', 'lifestyle', 'news', 'scholarships'],
+        'topics' => [
+            'community' => [],
+            'lifestyle' => [],
+            'news' => [
+                'reset' =>  [
+                  'enabled' => env('NEWS_SUBSCRIPTION_RESET_ENABLED', 'true'),
+                  'type' => env('NEWS_SUBSCRIPTION_RESET_TYPE', 'breakdown-activate-account'),
+                ],
+            ],
+            'scholarships' => [],
+        ],
     ],
     'rock_the_vote' => [
         'post' => [

--- a/resources/views/pages/partials/email-subscription.blade.php
+++ b/resources/views/pages/partials/email-subscription.blade.php
@@ -17,11 +17,14 @@
 <div class="form-group row">
   <label for="source-detail" class="col-sm-3 col-form-label" required>Subscription topics</label>
   <div class="col-sm-9">
-    @foreach ($config['topics'] as $topic)
+    @foreach ($config['topics'] as $topic => $config)
       <div class="form-check">
         <input class="form-check-input" name="topics[]" type="checkbox" value="{{ $topic }}" id="community">
         <label class="form-check-label" for="{{ $topic }}">
           {{ $topic }}
+          @isset($config['reset'])
+            <small class="form-text text-muted"> - Sending <code>{{$config['reset']['type']}}</code> email is {{$config['reset']['enabled'] ? 'ON' : 'OFF'}} for new users.</small>
+          @endif
         </label>
       </div>
     @endforeach


### PR DESCRIPTION
#### What's this PR do?

Modifies the email subscription import to execute a Northstar `POST /resets` request with the new `breakdown-activate-account` type introduced in https://github.com/DoSomething/northstar/pull/890 when a new user is created with `email_subscription_topics` containing `'news'`. 

#### How should this be reviewed?

Can verify a `call_to_action_email` event is created in Customer.io with type `breakdown-activate-account` upon submitting the email subscription import form with a new email and `news` selected.

![Screen Shot 2019-07-03 at 1 46 47 PM](https://user-images.githubusercontent.com/1236811/60624020-10449d00-9d99-11e9-932f-8b8499e7a257.png)

#### Any background context you want to provide?

Last implementation step is creating the Customer.io event triggered campaigns (and updating docs.dosomething.org) - waiting on final copy.

#### Relevant tickets

https://www.pivotaltracker.com/story/show/167046582
