### PR TITLE
Display failed jobs

### DIFF
--- a/app/Http/Controllers/FailedJobController.php
+++ b/app/Http/Controllers/FailedJobController.php
@@ -13,7 +13,12 @@ class FailedJobController extends Controller
     {
         $data = \DB::table('failed_jobs')->paginate(10);
         foreach ($data as $row) {
-            $row->json = json_decode($row->payload);
+            $json = json_decode($row->payload);
+            $row->command = unserialize($json->data->command);
+            $row->commandName = $json->data->commandName;
+            if ($row->commandName === 'Chompy\Jobs\CreateCallPowerPostInRogue') {
+                $row->parameters = $row->command->getParameters();
+            }
         }
 
         return \View::make('pages.failed-jobs')

--- a/app/Http/Controllers/FailedJobController.php
+++ b/app/Http/Controllers/FailedJobController.php
@@ -11,9 +11,12 @@ class FailedJobController extends Controller
      */
     public function index()
     {
-        $data = \DB::table('failed_jobs')->paginate(5);;
+        $data = \DB::table('failed_jobs')->paginate(10);
+        foreach ($data as $row) {
+            $row->json = json_decode($row->payload);
+        }
 
-        return \View::make('pages.home')
+        return \View::make('pages.failed-jobs')
             ->with('data', $data);
     }
 }

--- a/app/Http/Controllers/FailedJobController.php
+++ b/app/Http/Controllers/FailedJobController.php
@@ -5,6 +5,17 @@ namespace Chompy\Http\Controllers;
 class FailedJobController extends Controller
 {
     /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('role:admin');
+    }
+
+    /**
      * Display a listing of the resource.
      *
      * @return Response

--- a/app/Http/Controllers/FailedJobController.php
+++ b/app/Http/Controllers/FailedJobController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Chompy\Http\Controllers;
+
+class FailedJobController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return Response
+     */
+    public function index()
+    {
+        $data = \DB::table('failed_jobs')->paginate(5);;
+
+        return \View::make('pages.home')
+            ->with('data', $data);
+    }
+}

--- a/app/Jobs/CreateCallPowerPostInRogue.php
+++ b/app/Jobs/CreateCallPowerPostInRogue.php
@@ -112,4 +112,14 @@ class CreateCallPowerPostInRogue implements ShouldQueue
             'number_dialed_into' => $call['number_dialed_into'],
         ]);
     }
+
+    /**
+     * Returns the parameters passed to this job.
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
 }

--- a/config/database.php
+++ b/config/database.php
@@ -4,7 +4,9 @@
 if (env('CLEARDB_DATABASE_URL')) {
     $url = parse_url(env('CLEARDB_DATABASE_URL'));
     putenv('DB_HOST=' . $url['host']);
-    putenv('DB_PORT=' . $url['port']);
+    if (isset($url['port'])) {
+        putenv('DB_PORT=' . $url['port']);
+    }
     putenv('DB_DATABASE=' . substr($url['path'], 1));
     putenv('DB_USERNAME=' . $url['user']);
     putenv('DB_PASSWORD=' . $url['pass']);

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -9,6 +9,15 @@
             </button>
 
             <a class="navbar-brand">Chompy</a>
+            <ul class="nav navbar-nav">
+                @if (Auth::user())
+                    <li @if (Request::path() === 'failed-jobs') class="active" @endif>
+                        <a class="nav-item nav-link" href="{{  '/failed-jobs'  }}">
+                            Failed jobs
+                        </a>
+                    </li>
+                @endif
+            </ul>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">

--- a/resources/views/pages/failed-jobs.blade.php
+++ b/resources/views/pages/failed-jobs.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+<div>
+  {{$data->links()}}
+    <table class="table">
+    @foreach($data as $key => $row)
+        <tr class="row">
+          <td class="col-md-2">{{$row->failed_at}}</td>
+          <td class="col-md-4">
+            {{$row->json->displayName}}
+          </td>
+          <td class="col-md-6">
+            {{substr($row->exception, 0, 255)}}...
+          </td>    
+        </tr>
+    @endforeach
+    </table>
+  {{$data->links()}}
+</div>
+
+@stop

--- a/resources/views/pages/failed-jobs.blade.php
+++ b/resources/views/pages/failed-jobs.blade.php
@@ -6,10 +6,20 @@
   {{$data->links()}}
     <table class="table">
     @foreach($data as $key => $row)
+      {{info($row->id)}}
         <tr class="row">
-          <td class="col-md-2">{{$row->failed_at}}</td>
+          <td class="col-md-2">
+            <a href="failed-jobs/{{   $row->id  }}">{{$row->failed_at}}</a>
+          </td>
           <td class="col-md-4">
-            {{$row->json->displayName}}
+            <strong>{{$row->commandName}}</strong>
+            @isset($row->parameters)
+              <ul>
+                @foreach ($row->parameters as $key => $value)
+                  <li><code>{{$key}}</code> {{$value}}</li>
+                @endforeach
+              </ul>
+            @endif
           </td>
           <td class="col-md-6">
             {{substr($row->exception, 0, 255)}}...

--- a/resources/views/pages/failed-jobs.blade.php
+++ b/resources/views/pages/failed-jobs.blade.php
@@ -21,7 +21,7 @@
             @endif
           </td>
           <td class="col-md-6">
-            {{substr($row->exception, 0, 255)}}...
+            {{$row->errorMessage}}
           </td>    
         </tr>
     @endforeach

--- a/resources/views/pages/failed-jobs.blade.php
+++ b/resources/views/pages/failed-jobs.blade.php
@@ -6,10 +6,9 @@
   {{$data->links()}}
     <table class="table">
     @foreach($data as $key => $row)
-      {{info($row->id)}}
         <tr class="row">
           <td class="col-md-2">
-            <a href="failed-jobs/{{   $row->id  }}">{{$row->failed_at}}</a>
+            {{$row->failed_at}}
           </td>
           <td class="col-md-4">
             <strong>{{$row->commandName}}</strong>

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -2,17 +2,19 @@
 
 @section('main_content')
 
-<div class="jumbotron">
-    <div class="row">
-        <div class="col-md-4">
-            <img src="https://media.giphy.com/media/HEkBXK8qnIRuo/giphy.gif" width="300" alt="chompy" class="img-rounded center-block">
+<div>
+    @foreach($data as $key => $row)
+        <div class="row">
+          <div class="col-md-2">{{$key}}</div>
+          <div class="col-md-2">{{$row->failed_at}}</div>
+          <div class="col-md-8">
+            {{print_r(json_decode($row->payload), true)}}
+            <br />
+            <code>{{substr($row->exception, 0, 255)}}...</code>
+          </div>    
         </div>
-        <div class="col-md-8">
-            <h1 class="media-heading">Welcome to Chompy</h1>
-            <p>The DoSomething.org Importer app</p>
-            <p>Go ahead...import a CSV</p>
-        </div>
-    </div>
+    @endforeach
+    {{$data->links()}}
 </div>
 
 @stop

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -2,19 +2,17 @@
 
 @section('main_content')
 
-<div>
-    @foreach($data as $key => $row)
-        <div class="row">
-          <div class="col-md-2">{{$key}}</div>
-          <div class="col-md-2">{{$row->failed_at}}</div>
-          <div class="col-md-8">
-            {{print_r(json_decode($row->payload), true)}}
-            <br />
-            <code>{{substr($row->exception, 0, 255)}}...</code>
-          </div>    
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-4">
+            <img src="https://media.giphy.com/media/HEkBXK8qnIRuo/giphy.gif" width="300" alt="chompy" class="img-rounded center-block">
         </div>
-    @endforeach
-    {{$data->links()}}
+        <div class="col-md-8">
+            <h1 class="media-heading">Welcome to Chompy</h1>
+            <p>The DoSomething.org Importer app</p>
+            <p>Go ahead...import a CSV</p>
+        </div>
+    </div>
 </div>
 
 @stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,7 @@ $router->post('import/{importType}', 'ImportController@store')->name('import.sto
 Route::resource('failed-jobs', 'FailedJobController');
 
 Route::get('/', function () {
-    return view('pages.home', ['data' => []]);
+    return view('pages.home');
 });
 
 // Authentication

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,9 +13,10 @@
 
 $router->get('import/{importType}', 'ImportController@show')->name('import.show');
 $router->post('import/{importType}', 'ImportController@store')->name('import.store');
+Route::resource('failed-jobs', 'FailedJobController');
 
 Route::get('/', function () {
-    return view('pages.home');
+    return view('pages.home', ['data' => []]);
 });
 
 // Authentication


### PR DESCRIPTION
#### What's this PR do?

Adds a paginated view of the `failed_jobs` DB table, displaying the exception, and the parameters passed when the job is a `CreateCallPowerPostInRogue`.

<img width="1183" alt="failed-jobs" src="https://user-images.githubusercontent.com/1236811/60843153-b7a34480-a18a-11e9-8c1f-ccb2fb1bc363.png">


#### How should this be reviewed?

Verify the `/failed-jobs` content is displayed only for authenticated staff members.

#### Any background context you want to provide?

I wanted to dig into why we are seeing more Chompy errors reported in Papertrail every day, but Papertrail doesn't log any of the parameters passed. Exposing in the UI makes it easier for devs and non-devs to track down errors (and not have to use a DB tool to query the raw data).

I've found two errors so far from Call Power requests:

* Call Power requests with a `callpower_campaign_id` 21 are causing the `Undefined offset: 0 in /app/app/Services/Rogue.php:113` errors -- this suggests there is no action in Rogue with a corresponding `callpower_campaign_id` of 21.

* We're also able to see the data passed for the mysterious `ValidationException :The given data was invalid`, which seems to be thrown by Northstar from the stack trace -- this mobile number does not have enough digits

This brings up some further cleanup we could (should?) do -- if we receive a Call Power request with an invalid mobile number, there's no reason we should retry the request -- it should be deleted.

Ideally I'd love to add a single `/failed-jobs/:id` view to permalink to various errors, but held off to keep this PR reviewable (also would want to re-use some of the decoding/unserializing logic between the index and single views)

cc @ngjo 