### PR TITLE
Failed job permalink

### DIFF
--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -11,7 +11,7 @@
             <a class="navbar-brand">Chompy</a>
             <ul class="nav navbar-nav">
                 @if (Auth::user())
-                    <li @if (Request::path() === 'failed-jobs') class="active" @endif>
+                    <li @if (Request::is('failed-jobs*')) class="active" @endif>
                         <a class="nav-item nav-link" href="{{  '/failed-jobs'  }}">
                             Failed jobs
                         </a>

--- a/resources/views/pages/failed-jobs/index.blade.php
+++ b/resources/views/pages/failed-jobs/index.blade.php
@@ -8,7 +8,7 @@
     @foreach($data as $key => $row)
         <tr class="row">
           <td class="col-md-2">
-            {{$row->failed_at}}
+            <a href="/failed-jobs/{{$row->id}}">{{$row->failed_at}}</a>
           </td>
           <td class="col-md-4">
             <strong>{{$row->commandName}}</strong>

--- a/resources/views/pages/failed-jobs/show.blade.php
+++ b/resources/views/pages/failed-jobs/show.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+<div>
+  <form>
+    <div class="form-group row">
+      <label class="col-sm-3 col-form-label">Failed at</label>
+      <div class="col-sm-9">{{$data->failed_at}}</div>
+    </div>
+    <div class="form-group row">
+      <label class="col-sm-3 col-form-label">Command</label>
+      <div class="col-sm-9">
+        <strong>{{$data->commandName}}</strong>
+        @isset($data->parameters)
+          <ul>
+            @foreach ($data->parameters as $key => $value)
+              <li><code>{{$key}}</code> {{$value}}</li>
+            @endforeach
+          </ul>
+        @endif
+      </div>
+    </div>
+    <div class="form-group row">
+      <label class="col-sm-3 col-form-label">Exception</label>
+      <div class="col-sm-9">{{$data->exception}}</div>
+    </div>
+  </form>
+</div>
+
+@stop


### PR DESCRIPTION
#### What's this PR do?

Adds `/failed-job/:id` links to each row in the failed jobs list, permalinking to the failed job (and displaying the entire exception stack trace)

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

Would it make sense to add a delete button to the single view? Is that all we'd need in order to clear the queue of jobs we don't want to retry (e.g. the missing `first_name` column header, or a malformed phone number sent as an input parameter)

