### PR TITLE
Delete failed job via web

### DIFF
--- a/app/Http/Controllers/FailedJobController.php
+++ b/app/Http/Controllers/FailedJobController.php
@@ -62,7 +62,7 @@ class FailedJobController extends Controller
     public function show($id)
     {
         $data = \DB::table('failed_jobs')->where('id', '=', $id)->get();
-        if (!isset($data[0])) {
+        if (! isset($data[0])) {
             abort(404);
         }
 
@@ -80,11 +80,8 @@ class FailedJobController extends Controller
      */
     public function destroy($id)
     {
-        info('Deleting job '.$id);
-        $exitCode = Artisan::call('queue:forget', [
-            'id' => [$id]
-        ]);
-        info('exitCode '.$exitCode);
+        $exitCode = Artisan::call('queue:forget', ['id' => $id]);
+        info('Forgetting job:'.$id.' exitCode:'.$exitCode);
 
         return redirect('failed-jobs')
             ->with('status', 'Deleted job '.$id.' with exit code '.$exitCode.'.');

--- a/app/Http/Controllers/FailedJobController.php
+++ b/app/Http/Controllers/FailedJobController.php
@@ -62,6 +62,10 @@ class FailedJobController extends Controller
     public function show($id)
     {
         $data = \DB::table('failed_jobs')->where('id', '=', $id)->get();
+        if (!isset($data[0])) {
+            abort(404);
+        }
+
         $failedJob = $data[0];
         $this->addParsedPropertiesToFailedJob($failedJob);
 

--- a/app/Http/Controllers/FailedJobController.php
+++ b/app/Http/Controllers/FailedJobController.php
@@ -3,6 +3,7 @@
 namespace Chompy\Http\Controllers;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Artisan;
 
 class FailedJobController extends Controller
 {
@@ -55,6 +56,7 @@ class FailedJobController extends Controller
     /**
      * Display a failed job.
      *
+     * @param int $id
      * @return Response
      */
     public function show($id)
@@ -64,5 +66,23 @@ class FailedJobController extends Controller
         $this->addParsedPropertiesToFailedJob($failedJob);
 
         return view('pages.failed-jobs.show', ['data' => $failedJob]);
+    }
+
+    /**
+     * Delete a failed job.
+     *
+     * @param int $id
+     * @return Response
+     */
+    public function destroy($id)
+    {
+        info('Deleting job '.$id);
+        $exitCode = Artisan::call('queue:forget', [
+            'id' => [$id]
+        ]);
+        info('exitCode '.$exitCode);
+
+        return redirect('failed-jobs')
+            ->with('status', 'Deleted job '.$id.' with exit code '.$exitCode.'.');
     }
 }

--- a/app/Http/Controllers/FailedJobController.php
+++ b/app/Http/Controllers/FailedJobController.php
@@ -84,6 +84,6 @@ class FailedJobController extends Controller
         info('Forgetting job:'.$id.' exitCode:'.$exitCode);
 
         return redirect('failed-jobs')
-            ->with('status', 'Deleted job '.$id.' with exit code '.$exitCode.'.');
+            ->with('status', 'Deleted job '.$id.' (exit code '.$exitCode.').');
     }
 }

--- a/app/Http/Controllers/FailedJobController.php
+++ b/app/Http/Controllers/FailedJobController.php
@@ -31,7 +31,7 @@ class FailedJobController extends Controller
         $failedJob->commandName = $json->data->commandName;
         $failedJob->errorMessage = Str::limit($failedJob->exception, 255);
 
-        if ($failedJob->commandName === 'Chompy\Jobs\CreateCallPowerPostInRogue') {
+        if (Str::contains($failedJob->commandName, 'CallPower') || Str::contains($failedJob->commandName, 'SoftEdge')) {
             $command = unserialize($json->data->command);
             $failedJob->parameters = $command->getParameters();
         }

--- a/app/Jobs/CreateSoftEdgePostInRogue.php
+++ b/app/Jobs/CreateSoftEdgePostInRogue.php
@@ -74,4 +74,14 @@ class CreateSoftEdgePostInRogue implements ShouldQueue
             'campaign_target_district' => $email['campaign_target_district'],
         ]);
     }
+
+    /**
+     * Returns the parameters passed to this job.
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
 }

--- a/resources/views/pages/failed-jobs/show.blade.php
+++ b/resources/views/pages/failed-jobs/show.blade.php
@@ -3,7 +3,9 @@
 @section('main_content')
 
 <div>
-  <form>
+  <form action={{ url()->current() }} method="post">
+    {{csrf_field()}}
+    @method('delete')
     <div class="form-group row">
       <label class="col-sm-3 col-form-label">Failed at</label>
       <div class="col-sm-9">{{$data->failed_at}}</div>
@@ -24,6 +26,11 @@
     <div class="form-group row">
       <label class="col-sm-3 col-form-label">Exception</label>
       <div class="col-sm-9">{{$data->exception}}</div>
+    </div>
+     <div class="form-group row">
+        <div class="col-sm-9 col-sm-offset-3">
+          <input type="submit" class="btn btn-danger" value="Delete">
+        </div>   
     </div>
   </form>
 </div>

--- a/resources/views/pages/failed-jobs/show.blade.php
+++ b/resources/views/pages/failed-jobs/show.blade.php
@@ -29,7 +29,7 @@
     </div>
      <div class="form-group row">
         <div class="col-sm-9 col-sm-offset-3">
-          <input type="submit" class="btn btn-danger" value="Delete">
+          <input type="submit" class="btn btn-danger" value="Delete" onclick="return confirm('Are you sure you want to delete this job? This cannot be undone.')">
         </div>   
     </div>
   </form>


### PR DESCRIPTION
#### What's this PR do?

Follow up to #101 -- this PR adds a delete button (with a "Are you sure") confirmation to remove a failed job from the queue.

Also displays parameters for failed SoftEdge jobs.

#### How should this be reviewed?

👀 
I've been testing locally against the QA DB and verifying the failed job is no longer accessible upon submitting the delete form.

#### Any background context you want to provide?

This will be especially useful for failed jobs that will never complete no matter how many times they are retried (e.g. missing `email` column header)
