### PR TITLE
Skip anonymous mobile numbers in CallPower import

### DIFF
--- a/app/Jobs/CreateCallPowerPostInRogue.php
+++ b/app/Jobs/CreateCallPowerPostInRogue.php
@@ -37,8 +37,16 @@ class CreateCallPowerPostInRogue implements ShouldQueue
      */
     public function handle(Rogue $rogue)
     {
+        $mobile = $this->parameters['mobile'];
+
+        if (is_anonymous_mobile($mobile)) {
+            info('Cannot import phone call for anonymous mobile '.$mobile);
+
+            return;
+        }
+
         // Using the mobile number, get or create a northstar_id.
-        $user = $this->getOrCreateUser($this->parameters['mobile']);
+        $user = $this->getOrCreateUser($mobile);
 
         // Using the callpower_campaign_id, get the action id from Rogue.
         $actionId = $rogue->getActionIdFromCallPowerCampaignId($this->parameters['callpower_campaign_id']);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -16,3 +16,22 @@ function str_to_boolean($text)
 
     return filter_var($sanitized, FILTER_VALIDATE_BOOLEAN);
 }
+
+/**
+ * Determines if a mobile number is anonymous.
+ *
+ * @param string $mobile
+ * @return bool
+ */
+function is_anonymous_mobile($mobile)
+{
+    // @see https://support.twilio.com/hc/en-us/articles/223179988-Why-am-I-getting-calls-from-these-strange-numbers
+    return in_array($mobile, [
+        '+2562533',
+        '+266696687',
+        '+464',
+        '+7378742883',
+        '+86282452253',
+        '+8656696',
+    ]);
+}

--- a/tests/Unit/CallPowerTest.php
+++ b/tests/Unit/CallPowerTest.php
@@ -133,4 +133,29 @@ class CallPowerTest extends TestCase
             'number_dialed_into' => '+12028519273',
         ]);
     }
+
+    /**
+     * Test an anonymous mobile number is not processed.
+     *
+     * @return void
+     */
+    public function testAnonymousMobile()
+    {
+        // Mock a failed Northstar response.
+        $this->northstarMock->shouldNotReceive('getUser');
+        $this->northstarMock->shouldNotReceive('createUser');
+
+        CreateCallPowerPostInRogue::dispatch([
+            'mobile' => '+266696687',
+            'callpower_campaign_id' => 1,
+            'status' => 'busy',
+            'call_timestamp' => '2017-11-09 06:34:01.185035',
+            'call_duration' => 50,
+            'campaign_target_name' => 'Mickey Mouse',
+            'campaign_target_title' => 'Representative',
+            'campaign_target_district' => 'FL-7',
+            'callpower_campaign_name' => 'Test',
+            'number_dialed_into' => '+12028519273',
+        ]);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?

Adds a `is_anonymous_mobile` helper to skip CallPower jobs for [anonymous mobile numbers](https://shaun.net/notes/solving-the-mystery-of-calls-from-266696687/). Deploying this should clear the queue of the various requests we've been repeatedly retrying for +266696687.

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

* https://dosomething.slack.com/archives/CESE2J14G/p1554756524007300?thread_ts=1554731511.001700&cid=CESE2J14G
* https://support.twilio.com/hc/en-us/articles/223179988-Why-am-I-getting-calls-from-these-strange-numbers-

