### PR TITLE
Optional first_name in email subscription

### DIFF
--- a/app/Jobs/ImportEmailSubscription.php
+++ b/app/Jobs/ImportEmailSubscription.php
@@ -16,13 +16,13 @@ class ImportEmailSubscription implements ShouldQueue
     /**
      * The email to subscribe.
      *
-     * @var array
+     * @var string
      */
     protected $email;
     /**
      * The first name of the user to subscribe.
      *
-     * @var array
+     * @var string
      */
     protected $first_name;
     /**
@@ -41,15 +41,15 @@ class ImportEmailSubscription implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param string $email
+     * @param array $record
      * @param string $sourceDetail
      * @param array $emailSubscriptionTopics
      * @return void
      */
-    public function __construct($email, $firstName, $sourceDetail, $emailSubscriptionTopics)
+    public function __construct($record, $sourceDetail, $emailSubscriptionTopics)
     {
-        $this->email = $email;
-        $this->first_name = $firstName;
+        $this->email = $record['email'];
+        $this->first_name = isset($record['first_name']) ? $record['first_name'] : null;
         $this->source_detail = $sourceDetail;
         $this->email_subscription_topics = $emailSubscriptionTopics;
     }

--- a/app/Jobs/ImportFile.php
+++ b/app/Jobs/ImportFile.php
@@ -96,7 +96,7 @@ class ImportFile implements ShouldQueue
                 ImportRockTheVoteRecord::dispatch($record);
             }
             if ($this->importType === ImportType::$emailSubscription) {
-                ImportEmailSubscription::dispatch($record['email'], $record['first_name'], $this->importOptions['source_detail'], $this->importOptions['email_subscription_topics']);
+                ImportEmailSubscription::dispatch($record, $this->importOptions['source_detail'], $this->importOptions['email_subscription_topics']);
             }
             event(new LogProgress('', 'progress', ($offset / $this->totalRecords) * 100));
         }

--- a/app/Jobs/ImportFile.php
+++ b/app/Jobs/ImportFile.php
@@ -60,17 +60,6 @@ class ImportFile implements ShouldQueue
     }
 
     /**
-     * Get the tags that should be assigned to the job.
-     * TODO: Is this used anywhere?
-     *
-     * @return array
-     */
-    public function tags()
-    {
-        return [$this->importType];
-    }
-
-    /**
      * Fetch records from the filepath.
      *
      * @return array

--- a/app/Services/Rogue.php
+++ b/app/Services/Rogue.php
@@ -112,7 +112,7 @@ class Rogue extends RestApiClient
 
         if (empty($action['data'])) {
             info('action id not found for CallPower campaign id: ' . $callpowerCampaignId);
-            abort(500, 'Unable to get action data for CallPower campaign id: ' . $callpowerCampaignId);
+            throw new Exception('Unable to get action data for CallPower campaign id: ' . $callpowerCampaignId, 500);
         }
 
         return $action['data'][0]['id'];

--- a/app/Services/Rogue.php
+++ b/app/Services/Rogue.php
@@ -110,9 +110,9 @@ class Rogue extends RestApiClient
             'filter' => ['callpower_campaign_id' => $callpowerCampaignId],
         ]);
 
-        if (! $action['data'][0]['id']) {
+        if (empty($action['data'])) {
             info('action id not found for CallPower campaign id: ' . $callpowerCampaignId);
-            throw new Exception(500, 'Unable to get action data for CallPower campaign id : ' . $callpowerCampaignId);
+            abort(500, 'Unable to get action data for CallPower campaign id: ' . $callpowerCampaignId);
         }
 
         return $action['data'][0]['id'];

--- a/resources/views/pages/partials/email-subscription.blade.php
+++ b/resources/views/pages/partials/email-subscription.blade.php
@@ -1,8 +1,13 @@
 <div class="form-group">
     <h1>Email subscription</h1>
     <p class="lead">
-      Creates/updates users from uploaded CSV, expecting <code>email</code> and <code>first_name</code> column headers.
+      Creates or updates users and their email subscriptions per uploaded CSV.
     </p>
+    <p>Columns:</p>
+    <ul>
+      <li><code>email</code> - required</li>
+      <li><code>first_name</code> - optional</li>
+    </ul>
 </div>
 <h3>Users</h3>
 <div class="form-group row">

--- a/resources/views/pages/partials/rock-the-vote.blade.php
+++ b/resources/views/pages/partials/rock-the-vote.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group">
     <h1>Rock The Vote</h1>
     <p class="lead">
-      Creates/updates users and their voter registration post from uploaded Rock The Vote CSV.
+      Creates or updates users and their voter registration post per uploaded Rock The Vote CSV.
     </p>
     </p>
 </div>


### PR DESCRIPTION
#### What's this PR do?

* Modifies email subscription import to ignore a missing `first_name` column per https://dosomething.slack.com/archives/CA0N5FXND/p1562782007004100, so we'll no longer see failed jobs with `ErrorException: Undefined index: first_name` errors

* Fixes bug in Call Power import to properly return error message when action not found for a CallPower Campaign ID (instead of `ErrorException: Undefined offset: 0 in /app/app/Services/Rogue.php:113`)

* Removes unused `tags` function from `ImportFile`

#### How should this be reviewed?

👀 

