### PR TITLE
Delete imported CSVs after parsing them.

### DIFF
--- a/app/Jobs/ImportFile.php
+++ b/app/Jobs/ImportFile.php
@@ -101,6 +101,9 @@ class ImportFile implements ShouldQueue
             event(new LogProgress('', 'progress', ($offset / $this->totalRecords) * 100));
         }
 
+        // Now that we've chomped, delete the import file.
+        Storage::delete($this->filepath);
+
         event(new LogProgress('Done!', 'general'));
     }
 }


### PR DESCRIPTION
#### What's this PR do?
To reduce our risk of sensitive data exposure & make the account deletion process easier, we want to limit the locations we persist personal data. This pull request updates our `ImportFile` job to delete uploaded CSVs after we're done parsing them.

#### How should this be reviewed?

👀

#### Any background context you want to provide?

I'd originally hoped we could just serialize the CSV into the job itself. While [SQS theoretically supports payloads up to 2GB](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-limits.html#limits-messages), that's only via the Java AWS SDK! 😩 

> To send messages larger than 256 KB, you can use the [Amazon SQS Extended Client Library for Java](https://github.com/awslabs/amazon-sqs-java-extended-client-lib). This library allows you to send an Amazon SQS message that contains a reference to a message payload in Amazon S3. The maximum payload size is 2 GB.

And it turns out, that's what we're doing here (but managing the bucket ourselves).

#### Relevant tickets

[#167596552](https://www.pivotaltracker.com/story/show/167596552)
