### PR TITLE
Update RTV user voter registration status validation

### DIFF
--- a/app/Jobs/ImportRockTheVoteRecord.php
+++ b/app/Jobs/ImportRockTheVoteRecord.php
@@ -202,7 +202,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
             $newStatus = $this->getVoterRegistrationStatusChange($user->voter_registration_status, $this->record->voter_registration_status);
 
             if ($newStatus) {
-                $this->updateUser($user, [ 'voter_registration_status' => $newStatus ]);
+                $this->updateUser($user, ['voter_registration_status' => $newStatus]);
             }
         } else {
             $user = $this->createUser($this->record);

--- a/app/Jobs/ImportRockTheVoteRecord.php
+++ b/app/Jobs/ImportRockTheVoteRecord.php
@@ -310,12 +310,16 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     private function getVoterRegistrationStatusChange($currentStatus, $newStatus)
     {
+        // List includes status values expected from RTV as well as
+        // values potentially assigned from within Northstar.
         $statusHierarchy = [
             'uncertain',
             'ineligible',
+            'unregistered',
             'confirmed',
             'register-OVR',
             'register-form',
+            'registration_complete',
         ];
 
         $indexOfCurrentStatus = array_search($currentStatus, $statusHierarchy);

--- a/app/Jobs/ImportRockTheVoteRecord.php
+++ b/app/Jobs/ImportRockTheVoteRecord.php
@@ -199,9 +199,11 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
         $user = $this->getUser($this->record);
         if ($user && $user->id) {
-            $this->updateUser($user, [
-                'voter_registration_status' => $this->record->voter_registration_status,
-            ]);
+            $newStatus = $this->getVoterRegistrationStatusChange($user->voter_registration_status, $this->record->voter_registration_status);
+
+            if ($newStatus) {
+                $this->updateUser($user, [ 'voter_registration_status' => $newStatus ]);
+            }
         } else {
             $user = $this->createUser($this->record);
             $this->sendUserPasswordResetIfSubscribed($user);


### PR DESCRIPTION
#### What's this PR do?

This PR updates the Rock the Vote import logic to validate an existing User's new voter registration status against the current status to ensure it isn't bumped back within the hierarchy of statuses. 

We take advantage of the same method [already being used](https://github.com/DoSomething/chompy/blob/5826266c9cc2b7e9b21cf40ed3ac3a7c8afb5de9/app/Jobs/ImportRockTheVoteRecord.php#L233-#L236) when updating the Post's status, adding two new statuses to the list:
- `unregistered `: An option on the Northstar [web registration form](https://github.com/DoSomething/northstar/blob/1857c8e42ef164787a0accec2bb5fc28306b8f6f/resources/views/auth/register.blade.php#L87) for the user's to tell us they are not registered to vote.
- `registration_complete`: The [value assigned](https://github.com/DoSomething/chompy/blob/5826266c9cc2b7e9b21cf40ed3ac3a7c8afb5de9/app/Jobs/ImportRockTheVoteRecord.php#L48) to the user's status if the RTV record is `register-form` or `register-OVR`

#### How should this be reviewed?

I've tested this on QA, and the script ran just fine. I didn't manage to manually add some user's statuses to be higher in the hierarchy then the scripts records to ensure that that validation is still working but I can do that once we merge in the Northstar/Aurora PR via Aurora.

#### Any background context you want to provide?
This accompanies https://github.com/DoSomething/northstar/pull/903 where, in the effort to allow updating a User's voter registration status in Northstar without the hierarchy validation, we've opted to move that validation directly into Chompy. 

#### Relevant tickets

[Pivotal ID #165974120](https://www.pivotaltracker.com/story/show/165974120)
