### PR TITLE
Don't duplicate `email` in the post's `detail` field.

### DIFF
--- a/app/Jobs/ImportRockTheVoteRecord.php
+++ b/app/Jobs/ImportRockTheVoteRecord.php
@@ -154,7 +154,6 @@ class RockTheVoteRecord
             'Started registration',
             'Finish with State',
             'Status',
-            'Email address',
             'Home zip code',
         ];
 


### PR DESCRIPTION
#### What's this PR do?
This is just a quick data cleanup to stop storing `Email address` under the post `details` for Rock The Vote imports (since that's something we can always get from the user themselves).

#### How should this be reviewed?
Does this do the thing?

#### Any background context you want to provide?
Storing personal information under an unrelated field is a no-no because it means we can't reasonably audit access to this data (like we soon can with the "real" field), and it means we have to completely wipe `details` for posts when deleting accounts since it _may_ contain PII.

#### Relevant tickets
Fixes [#167745708](https://www.pivotaltracker.com/story/show/167745708).
