### PR TITLE
Include `rock-the-vote` source_detail on new users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,9 @@ ROCK_THE_VOTE_POST_ACTION_TYPE=voter-reg
 # The post source.
 ROCK_THE_VOTE_POST_SOURCE=rock-the-vote
 
+# The user source_detail.
+ROCK_THE_VOTE_USER_SOURCE_DETAIL=rock-the-vote
+
 # Comma separated list of the email subscription topics to save for new users
 ROCK_THE_VOTE_EMAIL_SUBSCRIPTION_TOPICS=community,scholarships
 

--- a/app/Jobs/ImportRockTheVoteRecord.php
+++ b/app/Jobs/ImportRockTheVoteRecord.php
@@ -38,6 +38,9 @@ class RockTheVoteRecord
                 $this->email_subscription_topics = explode(',', $config['user']['email_subscription_topics']);
             }
         }
+
+        $this->user_source_detail = $config['user']['source_detail'];
+        
         // Note: Not a typo, this column name does not have the trailing question mark.
         $smsOptIn = $record['Opt-in to Partner SMS/robocall'];
         if ($smsOptIn && $this->mobile) {
@@ -290,6 +293,11 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
         if (isset($record->sms_status)) {
             $userData['sms_status'] = $record->sms_status;
+        }
+
+        if (isset($record->user_source_detail)) {
+            $userData['source_detail'] = $record->user_source_detail;
+            $userData['source'] = config('services.northstar.client_credentials.client_id');
         }
 
         $user = gateway('northstar')->asClient()->createUser($userData);

--- a/app/Jobs/ImportRockTheVoteRecord.php
+++ b/app/Jobs/ImportRockTheVoteRecord.php
@@ -40,7 +40,7 @@ class RockTheVoteRecord
         }
 
         $this->user_source_detail = $config['user']['source_detail'];
-        
+
         // Note: Not a typo, this column name does not have the trailing question mark.
         $smsOptIn = $record['Opt-in to Partner SMS/robocall'];
         if ($smsOptIn && $this->mobile) {

--- a/config/import.php
+++ b/config/import.php
@@ -26,6 +26,7 @@ return [
         ],
         'user' => [
             'email_subscription_topics' => env('ROCK_THE_VOTE_EMAIL_SUBSCRIPTION_TOPICS', 'community'),
+            'source_detail' => env('ROCK_THE_VOTE_USER_SOURCE_DETAIL', 'rock-the-vote'),
         ],
     ],
 ];

--- a/resources/views/pages/partials/rock-the-vote.blade.php
+++ b/resources/views/pages/partials/rock-the-vote.blade.php
@@ -16,6 +16,15 @@
     </div>
 </div>
 <div class="form-group row">
+    <label class="col-sm-3 col-form-label">User source detail</label>
+    <div class="col-sm-9">
+        <p class="form-control-static"><code>{{ $config['user']['source_detail'] }}</code></p>
+        <small class="form-text text-muted">
+          The source details we will store on new users.
+        </small>
+    </div>
+</div>
+<div class="form-group row">
     <label class="col-sm-3 col-form-label">Send Password Reset</label>
     <div class="col-sm-9">
         <p class="form-control-static">{{ $config['reset']['enabled'] ? 'ON' : 'OFF' }}</p>


### PR DESCRIPTION
#### What's this PR do?

- Updated `.env.example` to include `ROCK_THE_VOTE_USER_SOURCE_DETAIL`
- Updated config to pull in `ROCK_THE_VOTE_USER_SOURCE_DETAIL` or fall back on `rock-the-vote` for `source_detail`
- If we have `source_detail`, when we create a new user, we send that to Northstar as well as `config('services.northstar.client_credentials.client_id')` for the `source` (which is the same value it would have been had we sent nothing)
- Updated frontend to display this new setting:
![image](https://user-images.githubusercontent.com/4240292/66612723-a3028e00-eb77-11e9-8ab1-ca1913ee6ace.png)


#### How should this be reviewed?

[Here's](https://admin-dev.dosomething.org/users/5d9fb52ad5b96b04d86def12) an example user that I imported with these updates, check out the `source` and `source_detail`.

#### Any background context you want to provide?

This will make these users easier to track.

#### Relevant tickets

Fixes [#167671819](https://www.pivotaltracker.com/story/show/167671819)
