### PR TITLE
Additional activate account emails

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -49,9 +49,9 @@ class ImportController extends Controller
         ];
         if ($importType === ImportType::$emailSubscription) {
             $rules['source-detail'] = 'required';
-            $rules['topics'] = 'required';
+            $rules['topic'] = 'required';
             $importOptions = [
-                'email_subscription_topics' => $request->input('topics'),
+                'email_subscription_topic' => $request->input('topic'),
                 'source_detail' => $request->input('source-detail'),
             ];
         }

--- a/app/Jobs/ImportFile.php
+++ b/app/Jobs/ImportFile.php
@@ -96,7 +96,7 @@ class ImportFile implements ShouldQueue
                 ImportRockTheVoteRecord::dispatch($record);
             }
             if ($this->importType === ImportType::$emailSubscription) {
-                ImportEmailSubscription::dispatch($record, $this->importOptions['source_detail'], $this->importOptions['email_subscription_topics']);
+                ImportEmailSubscription::dispatch($record, $this->importOptions['source_detail'], $this->importOptions['email_subscription_topic']);
             }
             event(new LogProgress('', 'progress', ($offset / $this->totalRecords) * 100));
         }

--- a/config/import.php
+++ b/config/import.php
@@ -3,15 +3,30 @@
 return [
     'email_subscription' => [
         'topics' => [
-            'community' => [],
-            'lifestyle' => [],
+            'community' => [
+                'reset' =>  [
+                  'enabled' => env('COMMUNITY_SUBSCRIPTION_RESET_ENABLED', 'true'),
+                  'type' => env('COMMUNITY_SUBSCRIPTION_RESET_TYPE', 'wyd-activate-account'),
+                ],
+            ],
+            'lifestyle' => [
+                'reset' =>  [
+                  'enabled' => env('LIFESTYLE_SUBSCRIPTION_RESET_ENABLED', 'true'),
+                  'type' => env('LIFESTYLE_SUBSCRIPTION_RESET_TYPE', 'boost-activate-account'),
+                ],
+            ],
             'news' => [
                 'reset' =>  [
                   'enabled' => env('NEWS_SUBSCRIPTION_RESET_ENABLED', 'true'),
                   'type' => env('NEWS_SUBSCRIPTION_RESET_TYPE', 'breakdown-activate-account'),
                 ],
             ],
-            'scholarships' => [],
+            'scholarships' => [
+                'reset' =>  [
+                  'enabled' => env('SCHOLARSHIPS_SUBSCRIPTION_RESET_ENABLED', 'true'),
+                  'type' => env('SCHOLARSHIPS_SUBSCRIPTION_RESET_TYPE', 'pays-to-do-good-activate-account'),
+                ],
+            ],
         ],
     ],
     'rock_the_vote' => [

--- a/resources/views/pages/partials/email-subscription.blade.php
+++ b/resources/views/pages/partials/email-subscription.blade.php
@@ -20,11 +20,11 @@
   </div>
 </div>
 <div class="form-group row">
-  <label for="source-detail" class="col-sm-3 col-form-label" required>Subscription topics</label>
+  <label for="source-detail" class="col-sm-3 col-form-label" required>Subscription topic</label>
   <div class="col-sm-9">
     @foreach ($config['topics'] as $topic => $config)
       <div class="form-check">
-        <input class="form-check-input" name="topics[]" type="checkbox" value="{{ $topic }}" id="community">
+        <input class="form-check-input" name="topic" type="radio" value="{{ $topic }}" id="community">
         <label class="form-check-label" for="{{ $topic }}">
           {{ $topic }}
           @isset($config['reset'])


### PR DESCRIPTION
#### What's this PR do?

This PR configures the Email Subscription import to send the new reset types added in https://github.com/DoSomething/northstar/pull/944. It also alters the import form to restrict the email subscriptions to a single topic, to avoid mistakenly sending multiple emails if two topics were selected.

#### How should this be reviewed?

Running the import for a newly added reset type will create corresponding `call_to_action_email` events in Customer.io .

#### Any background context you want to provide?

Per the steps documented in https://github.com/DoSomething/northstar/pull/944, the last outstanding task is to create the Customer.io campaigns in staging and production for each new reset type.

#### Relevant tickets

https://www.pivotaltracker.com/story/show/169043520
