### PR TITLE
Adds unauthorized view

### DIFF
--- a/resources/views/auth/unauthorized.blade.php
+++ b/resources/views/auth/unauthorized.blade.php
@@ -1,0 +1,9 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+<div class="jumbotron">
+    <p>Sorry, you are not authorized to view this application.</p>
+</div>
+
+@stop


### PR DESCRIPTION
#### What's this PR do?

Adds a view to display an unauthorized message, instead of the 500 error page.

<img width="1022" alt="Screen Shot 2019-10-21 at 4 30 08 PM" src="https://user-images.githubusercontent.com/1236811/67250497-804a6200-f420-11e9-9bb4-f828b7e86c36.png">

#### How should this be reviewed?

Login to Northstar with a non-staff account, and verify the unauthorized view appears.

#### Any background context you want to provide?

We see unauthorized errors from time to time, which seem to be resolved by logging out of Chompy and then re-logging in. I ran into this today and thought adding this message could help quite a bit with troubleshooting.

