### PR TITLE
Don't unset 'first_name' if not included in CSV.

### DIFF
--- a/app/Jobs/ImportEmailSubscription.php
+++ b/app/Jobs/ImportEmailSubscription.php
@@ -120,11 +120,13 @@ class ImportEmailSubscription implements ShouldQueue
         $existingTopics = ! empty($user->email_subscription_topics) ? $user->email_subscription_topics : [];
         $newTopics = array_unique(array_merge($existingTopics, [$this->email_subscription_topic]));
 
-        gateway('northstar')->asClient()->updateUser($user->id, [
+        // Update the user, filtering out null values so we don't unset an existing 'first_name'.
+        gateway('northstar')->asClient()->updateUser($user->id, array_filter([
             'first_name' => $this->first_name,
             'email_subscription_status' => true,
             'email_subscription_topics'  => $newTopics,
-        ]);
+        ]));
+
         info('Subscribed existing user', ['user' => $user->id]);
     }
 


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes an issue where `ImportEmailSubscription` would unset a user's existing `first_name` if the value didn't exist in the CSV, which was causing some existing users to lose their first names. Full details [in the Pivotal ticket](https://www.pivotaltracker.com/story/show/169349223).

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This will stop this from happening on future email imports. We'll have to consider if/how we can fix this issue for previous imports as a follow-up task.

#### Relevant tickets

[#169349223](https://www.pivotaltracker.com/story/show/169349223)
