### PR TITLE
Rename jobs for consistency

### DIFF
--- a/app/Http/Controllers/ThirdParty/CallPowerController.php
+++ b/app/Http/Controllers/ThirdParty/CallPowerController.php
@@ -5,7 +5,7 @@ namespace Chompy\Http\Controllers\ThirdParty;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Chompy\Http\Controllers\Controller;
-use Chompy\Jobs\CreateCallPowerPostInRogue;
+use Chompy\Jobs\ImportCallPowerRecord;
 
 class CallPowerController extends Controller
 {
@@ -45,6 +45,6 @@ class CallPowerController extends Controller
         );
 
         // Send to queued job.
-        CreateCallPowerPostInRogue::dispatch($parameters);
+        ImportCallPowerRecord::dispatch($parameters);
     }
 }

--- a/app/Http/Controllers/ThirdParty/SoftEdgeController.php
+++ b/app/Http/Controllers/ThirdParty/SoftEdgeController.php
@@ -5,7 +5,7 @@ namespace Chompy\Http\Controllers\ThirdParty;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Chompy\Http\Controllers\Controller;
-use Chompy\Jobs\CreateSoftEdgePostInRogue;
+use Chompy\Jobs\ImportSoftEdgeRecord;
 
 class SoftEdgeController extends Controller
 {
@@ -39,7 +39,7 @@ class SoftEdgeController extends Controller
         ]);
 
         // Send to queued job.
-        CreateSoftEdgePostInRogue::dispatch($parameters);
+        ImportSoftEdgeRecord::dispatch($parameters);
 
         return response()->json(['success' => true]);
     }

--- a/app/Jobs/ImportCallPowerRecord.php
+++ b/app/Jobs/ImportCallPowerRecord.php
@@ -9,7 +9,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 
-class CreateCallPowerPostInRogue implements ShouldQueue
+class ImportCallPowerRecord implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 

--- a/app/Jobs/ImportSoftEdgeRecord.php
+++ b/app/Jobs/ImportSoftEdgeRecord.php
@@ -8,7 +8,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 
-class CreateSoftEdgePostInRogue implements ShouldQueue
+class ImportSoftEdgeRecord implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 

--- a/tests/Unit/CallPowerTest.php
+++ b/tests/Unit/CallPowerTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit;
 use Exception;
 use Tests\TestCase;
 use Illuminate\Http\Response;
-use Chompy\Jobs\CreateCallPowerPostInRogue;
+use Chompy\Jobs\ImportCallPowerRecord;
 
 class CallPowerTest extends TestCase
 {
@@ -89,7 +89,7 @@ class CallPowerTest extends TestCase
 
         $this->expectException(Exception::class);
 
-        CreateCallPowerPostInRogue::dispatch([
+        ImportCallPowerRecord::dispatch([
             'mobile' => '1234567891',
             'callpower_campaign_id' => 1,
             'status' => 'busy',
@@ -120,7 +120,7 @@ class CallPowerTest extends TestCase
 
         $this->expectException(Exception::class);
 
-        CreateCallPowerPostInRogue::dispatch([
+        ImportCallPowerRecord::dispatch([
             'mobile' => '1234567891',
             'callpower_campaign_id' => 1,
             'status' => 'busy',
@@ -145,7 +145,7 @@ class CallPowerTest extends TestCase
         $this->northstarMock->shouldNotReceive('getUser');
         $this->northstarMock->shouldNotReceive('createUser');
 
-        CreateCallPowerPostInRogue::dispatch([
+        ImportCallPowerRecord::dispatch([
             'mobile' => '+266696687',
             'callpower_campaign_id' => 1,
             'status' => 'busy',


### PR DESCRIPTION
### What's this PR do?

This pull request changes the name of `CreateCallPowerPostInRogue` (which also could create a new user in Northstar) and `CreateSoftEdgePostInRogue` to match the naming convention of the other import jobs and improve readability.

### How should this be reviewed?

👀 

### Any background context you want to provide?

As we consider adding new jobs to automate the RTV CSV creation and download, it felt like a good time to make this quick cleanup change.

Fun fact -- you can view all the email or phone call posts these jobs create by filtering by post type in Gambit Admin, e.g. https://gambit-admin-staging.herokuapp.com/posts?type=email (filtering by `phone-call` returns a GraphQL error because of an extra post status -- Expected a value of type "ReviewStatus" but received: "INCOMPLETE"). It'd be nice to port filtering by type over to Rogue one rainy day.



### Checklist


- [ ] Added appropriate feature/unit tests.
