### PR TITLE
View RTV logs by user

### DIFF
--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -27,6 +27,6 @@ class UserController extends Controller
     {
         $rows = RockTheVoteLog::where('user_id', $id)->paginate(15);
 
-        return view('pages.users.show', ['user_id' => $id, 'rows' => $rows]);
+        return view('pages.users.show', ['id' => $id, 'rows' => $rows]);
     }
 }

--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Chompy\Http\Controllers\Web;
+
+use Illuminate\Http\Request;
+use Chompy\Models\RockTheVoteLog;
+use Chompy\Http\Controllers\Controller;
+
+class UserController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('role:admin');
+    }
+
+    /**
+     * Displays logs for a user.
+     *
+     * @return Response
+     */
+    public function show($id)
+    {
+        $rows = RockTheVoteLog::where('user_id', $id)->paginate(15);
+
+        return view('pages.users.show', ['user_id' => $id, 'rows' => $rows]);
+    }
+}

--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -2,7 +2,6 @@
 
 namespace Chompy\Http\Controllers\Web;
 
-use Illuminate\Http\Request;
 use Chompy\Models\RockTheVoteLog;
 use Chompy\Http\Controllers\Controller;
 

--- a/resources/views/pages/import-files/index.blade.php
+++ b/resources/views/pages/import-files/index.blade.php
@@ -3,6 +3,7 @@
 @section('main_content')
 
 <div>
+    <p><strong>Note:</strong> We didn't start saving this data locally until Feb 27, 2020.</p>
     <table class="table">
         <thead>
           <tr class="row">

--- a/resources/views/pages/import-files/show.blade.php
+++ b/resources/views/pages/import-files/show.blade.php
@@ -10,7 +10,7 @@
         <strong>{{$importFile->import_type}}</strong> ({{$importFile->row_count}} rows)
     </p>
     @if ($importFile->import_type === \Chompy\ImportType::$rockTheVote)
-        @include('pages.partials.rock-the-vote.logs', ['rows' => $rows])
+        @include('pages.partials.rock-the-vote.logs', ['rows' => $rows, 'user_id' => null])
     @endif
 </div>
 

--- a/resources/views/pages/partials/rock-the-vote/logs.blade.php
+++ b/resources/views/pages/partials/rock-the-vote/logs.blade.php
@@ -2,7 +2,7 @@
     <thead>
         <tr class="row">
             <th class="col-md-2">Started Registration</th>
-            <th class="col-md-2">User</th>
+            <th class="col-md-2">{{$user_id ? 'Import File' : 'User'}}</th>
             <th class="col-md-1">Status</th>
             <th class="col-md-3">Tracking Source</th>
             <th class="col-md-2">Finish With State</th>
@@ -15,7 +15,9 @@
                 {{$row->started_registration}}
             </td>    
             <td class="col-md-2">
-                {{$row->user_id}}
+                <a href="{{$user_id ? '/import-files/' . $row->import_file_id : '/users/' . $row->user_id}}">
+                    {{$user_id ? $row->import_file_id : $row->user_id}}
+                </a>
             </td> 
             <td class="col-md-1">
                 {{$row->status}}

--- a/resources/views/pages/users/show.blade.php
+++ b/resources/views/pages/users/show.blade.php
@@ -4,8 +4,11 @@
 
 <div>
     <h1>{{$user_id}}</h1>
-    <p><a href="#">View in Rogue</a></p>
+    <p>
+        <a href="{{config('services.rogue.url') . '/users/' . $user_id}}">View user in Rogue</a>
+    </p>
     <h3>Rock The Vote</h3>
+    <p><strong>Note:</strong> We didn't start saving this data locally until Feb 27, 2020.</p>
     @include('pages.partials.rock-the-vote.logs', ['user_id' => $user_id, 'rows' => $rows])
 </div>
 

--- a/resources/views/pages/users/show.blade.php
+++ b/resources/views/pages/users/show.blade.php
@@ -3,13 +3,13 @@
 @section('main_content')
 
 <div>
-    <h1>{{$user_id}}</h1>
+    <h1>{{$id}}</h1>
     <p>
-        <a href="{{config('services.rogue.url') . '/users/' . $user_id}}">View user in Rogue</a>
+        <a href="{{config('services.rogue.url') . '/users/' . $id}}">View user in Rogue</a>
     </p>
     <h3>Rock The Vote</h3>
     <p><strong>Note:</strong> We didn't start saving this data locally until Feb 27, 2020.</p>
-    @include('pages.partials.rock-the-vote.logs', ['user_id' => $user_id, 'rows' => $rows])
+    @include('pages.partials.rock-the-vote.logs', ['user_id' => $id, 'rows' => $rows])
 </div>
 
 @stop

--- a/resources/views/pages/users/show.blade.php
+++ b/resources/views/pages/users/show.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+<div>
+    <h1>{{$user_id}}</h1>
+    <p><a href="#">View in Rogue</a></p>
+    <h3>Rock The Vote</h3>
+    @include('pages.partials.rock-the-vote.logs', ['user_id' => $user_id, 'rows' => $rows])
+</div>
+
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,8 @@ $router->post('import/{importType}', 'ImportFileController@store')->name('import
 
 Route::resource('import-files', 'ImportFileController', ['only' => ['index', 'show']]);
 
+Route::resource('users', 'UserController', ['only' => ['show']]);
+
 Route::get('/', function () {
     return view('pages.home');
 });


### PR DESCRIPTION
### What's this PR do?

This pull request adds a simple `/user/:id` page to view all RTV logs (added in #120) that we've saved for a given user.

<img width="600" alt="Screen Shot 2020-02-28 at 9 33 22 AM" src="https://user-images.githubusercontent.com/1236811/75571107-65f74500-5a0d-11ea-9664-7110d9958026.png">

### How should this be reviewed?

👀 

### Any background context you want to provide?

This should significantly help us plan out how to better map a user's voter registration journey per the  [Problems/Solutions doc](https://docs.google.com/document/d/1An-JD0Tp6bQIvqYHfDpZvTjNwPkBxB8soB22ZLJ-lG8/).

### Relevant tickets

References [Pivotal #171472626](https://www.pivotaltracker.com/story/show/171472626).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
