### PR TITLE
Adds support to create Rock The Vote reports via API

### DIFF
--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -3,6 +3,7 @@
 namespace Chompy\Http\Controllers\Web;
 
 use Illuminate\Http\Request;
+use Chompy\Services\RockTheVote;
 use Chompy\Models\RockTheVoteReport;
 use Chompy\Http\Controllers\Controller;
 
@@ -42,7 +43,7 @@ class RockTheVoteReportController extends Controller
         ]);
 
         // Execute API request to create a new Rock The Vote Report.
-        $apiResponse = app('Chompy\Services\RockTheVote')->createReport($request->all());
+        $apiResponse = app(RockTheVote::class)->createReport($request->all());
 
         // Log our created report in the database, to keep track of reports requested.
         $report = RockTheVoteReport::createFromApiResponse($apiResponse, $request['since'], $request['before']);
@@ -59,7 +60,7 @@ class RockTheVoteReportController extends Controller
     {
         return view('pages.rock-the-vote-reports.show', [
             'id' => $id,
-            'report' => app('Chompy\Services\RockTheVote')->getReportStatusById($id),
+            'report' => app(RockTheVote::class)->getReportStatusById($id),
         ]);
     }
 }

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -45,8 +45,7 @@ class RockTheVoteReportController extends Controller
         $apiResponse = app('Chompy\Services\RockTheVote')->createReport($request->all());
 
         // Log our created report in the database, to keep track of reports requested.
-        $report = RockTheVoteReport::createFromApiResponse($apiResponse, $request['since'], $request['before']); 
-
+        $report = RockTheVoteReport::createFromApiResponse($apiResponse, $request['since'], $request['before']);
 
         return redirect('rock-the-vote/reports/' . $report->id);
     }

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -2,6 +2,7 @@
 
 namespace Chompy\Http\Controllers\Web;
 
+use Illuminate\Http\Request;
 use Chompy\Models\RockTheVoteReport;
 use Chompy\Http\Controllers\Controller;
 

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -30,13 +30,12 @@ class RockTheVoteReportController extends Controller
     }
 
     /**
-     * Execute API request to create a Rock The Vote Report, and save to storage.
+     * Execute API request to create a Rock The Vote Report, and save ID to storage.
      *
      * @param  \Illuminate\Http\Request  $request
      */
     public function store(Request $request)
     {
-        // @TODO: Figure out expected format, not having any luck with passing these.
         $this->validate($request, [
             'since' => ['required'],
             'before' => ['required'],
@@ -61,7 +60,7 @@ class RockTheVoteReportController extends Controller
     }
 
     /**
-     * Display a Rock The Vote report.
+     * Display Rock The Vote Report status information.
      *
      * @return Response
      */

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -30,7 +30,7 @@ class RockTheVoteReportController extends Controller
     }
 
     /**
-     * Store a newly created Rock The Vote report in storage.
+     * Execute API request to create a Rock The Vote Report, and save to storage.
      *
      * @param  \Illuminate\Http\Request  $request
      */
@@ -42,7 +42,7 @@ class RockTheVoteReportController extends Controller
             'before' => ['required'],
         ]);
 
-        // Execute API request to create a new Rock The Vote report.
+        // Execute API request to create a new Rock The Vote Report.
         $report = app('Chompy\Services\RockTheVote')->createReport($request->all());
 
         // Parse response to find the new Rock The Vote Report ID.

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -2,6 +2,7 @@
 
 namespace Chompy\Http\Controllers\Web;
 
+use Chompy\Models\RockTheVoteReport;
 use Chompy\Http\Controllers\Controller;
 
 class RockTheVoteReportController extends Controller
@@ -15,6 +16,35 @@ class RockTheVoteReportController extends Controller
     {
         $this->middleware('auth');
         $this->middleware('role:admin');
+    }
+
+    /**
+     * Create a Rock The Vote report.
+     *
+     * @return Response
+     */
+    public function create()
+    {
+        return view('pages.rock-the-vote-reports.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function store(Request $request)
+    {
+        $this->validate($request, [
+            'id' => ['required', 'integer'],
+            'since' => ['required'],
+            'before' => ['required'],
+        ]);
+
+        // @TODO: Get Report ID by via RTV API request.
+        $report = RockTheVoteReport::create($request->all());
+
+        return redirect('rock-the-vote/reports/' . $report->id);
     }
 
     /**

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -42,21 +42,13 @@ class RockTheVoteReportController extends Controller
         ]);
 
         // Execute API request to create a new Rock The Vote Report.
-        $report = app('Chompy\Services\RockTheVote')->createReport($request->all());
-
-        // Parse response to find the new Rock The Vote Report ID.
-        $statusUrlParts = explode('/', $report->status_url);
-        $reportId = $statusUrlParts[count($statusUrlParts) - 1];
+        $apiResponse = app('Chompy\Services\RockTheVote')->createReport($request->all());
 
         // Log our created report in the database, to keep track of reports requested.
-        RockTheVoteReport::create([
-            'id' => $reportId,
-            'since' => $request['since'],
-            'before' => $request['before'],
-            'status' => $report->status,
-        ]);
+        $report = RockTheVoteReport::createFromApiResponse($apiResponse, $request['since'], $request['before']); 
 
-        return redirect('rock-the-vote/reports/' . $reportId);
+
+        return redirect('rock-the-vote/reports/' . $report->id);
     }
 
     /**

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -35,4 +35,27 @@ class RockTheVoteReport extends Model
     public static $indexes = [
         'status',
     ];
+
+    /**
+     * Logs a Rock The Vote Reported created via API request.
+     *
+     * @param array $response
+     * @param string $since
+     * @param string $before
+     * @return RockTheVoteReport
+     */
+    public static function createFromApiResponse($response, $since = null, $before = null)
+    {
+        // Parse response to find the new Rock The Vote Report ID.
+        $statusUrlParts = explode('/', $response->status_url);
+        $reportId = $statusUrlParts[count($statusUrlParts) - 1];
+
+        // Log our created report in the database, to keep track of reports requested.
+        return static::create([
+            'id' => $reportId,
+            'since' => $since,
+            'before' => $before,
+            'status' => $response->status,
+        ]);
+    }
 }

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -21,7 +21,7 @@ class RockTheVoteReport extends Model
         'status',
         'since',
         'before',
-        'imported',
+        'imported_at',
     ];
 
     /**

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -37,7 +37,7 @@ class RockTheVoteReport extends Model
     ];
 
     /**
-     * Logs a Rock The Vote Reported created via API request.
+     * Logs a Rock The Vote Report that we've created via API request.
      *
      * @param array $response
      * @param string $since

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -30,7 +30,6 @@ class RockTheVoteReport extends Model
      * @var array
      */
     protected $dates = [
-        'status',
         'dispatched_at',
     ];
 
@@ -44,14 +43,15 @@ class RockTheVoteReport extends Model
      */
     public static $indexes = [
         'status',
+        'dispatched_at',
     ];
 
     /**
      * Logs a Rock The Vote Report that we've created via API request.
      *
      * @param array $response
-     * @param string $since
-     * @param string $before
+     * @param datetime $since
+     * @param datetime $before
      * @return RockTheVoteReport
      */
     public static function createFromApiResponse($response, $since = null, $before = null)

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -30,6 +30,8 @@ class RockTheVoteReport extends Model
      * @var array
      */
     protected $dates = [
+        'since',
+        'before',
         'dispatched_at',
     ];
 

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Chompy\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RockTheVoteReport extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'status',
+        'imported',
+    ];
+
+    /**
+     * Attributes that can be queried when filtering.
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * any of these are actual indexes on the database... but they should be!
+     *
+     * @var array
+     */
+    public static $indexes = [
+        'status',
+    ];
+}

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -21,7 +21,17 @@ class RockTheVoteReport extends Model
         'status',
         'since',
         'before',
-        'imported_at',
+        'dispatched_at',
+    ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'status',
+        'dispatched_at',
     ];
 
     /**

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -7,6 +7,11 @@ use Illuminate\Database\Eloquent\Model;
 class RockTheVoteReport extends Model
 {
     /**
+     * We use the externally created Rock the Vote ID as our primary key.
+     */
+    public $incrementing = false;
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array
@@ -14,6 +19,8 @@ class RockTheVoteReport extends Model
     protected $fillable = [
         'id',
         'status',
+        'since',
+        'before',
         'imported',
     ];
 

--- a/app/Services/RockTheVote.php
+++ b/app/Services/RockTheVote.php
@@ -21,10 +21,28 @@ class RockTheVote
         $this->client = new \GuzzleHttp\Client([
             'base_uri' => $config['url'] . '/api/v4/',
         ]);
+
         $this->authQuery = [
             'partner_API_key' => $config['api_key'],
             'partner_id' => $config['partner_id'],
         ];
+    }
+
+    /**
+     * Creates a Rock The Vote report.
+     *
+     * @param array $params
+     * @return array
+     */
+    public function createReport($params)
+    {
+        $response = $this->client->post('registrant_reports', [
+            // @TODO - since/before causing intenral server error
+            // when trying to pass array_merge($params, $this->authQuery)
+            'json' => $this->authQuery,
+        ]);
+
+        return json_decode($response->getBody()->getContents());
     }
 
     /**

--- a/app/Services/RockTheVote.php
+++ b/app/Services/RockTheVote.php
@@ -30,6 +30,7 @@ class RockTheVote
 
     /**
      * Creates a Rock The Vote report.
+     * @see https://rock-the-vote.github.io/Voter-Registration-Tool-API-Docs/#reports
      *
      * @param array $params
      * @return array
@@ -47,7 +48,7 @@ class RockTheVote
 
     /**
      * Get a Rock The Vote report by ID.
-     * @see https://rock-the-vote.github.io/Voter-Registration-Tool-API-Docs/?emci=da3e348b-feda-e911-b5e9-2818784d6d68&emdi=925c56a9-00db-e911-b5e9-2818784d6d68&ceid=2948039#report_status
+     * @see https://rock-the-vote.github.io/Voter-Registration-Tool-API-Docs/#report_status
      *
      * @param int $id
      * @return array

--- a/app/Services/RockTheVote.php
+++ b/app/Services/RockTheVote.php
@@ -38,9 +38,7 @@ class RockTheVote
     public function createReport($params)
     {
         $response = $this->client->post('registrant_reports', [
-            // @TODO - since/before causing intenral server error
-            // when trying to pass array_merge($params, $this->authQuery)
-            'json' => $this->authQuery,
+            'json' => array_merge($params, $this->authQuery),
         ]);
 
         return json_decode($response->getBody()->getContents());

--- a/database/migrations/2020_03_06_000200_create_rock_the_vote_reports_table.php
+++ b/database/migrations/2020_03_06_000200_create_rock_the_vote_reports_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateRockTheVoteReportsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('rock_the_vote_reports', function (Blueprint $table) {
+            $table->string('status')->index();
+            $table->string('since');
+            $table->string('before');
+            $table->string('imported');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('rock_the_vote_reports');
+    }
+}

--- a/database/migrations/2020_03_06_000200_create_rock_the_vote_reports_table.php
+++ b/database/migrations/2020_03_06_000200_create_rock_the_vote_reports_table.php
@@ -14,11 +14,13 @@ class CreateRockTheVoteReportsTable extends Migration
     public function up()
     {
         Schema::create('rock_the_vote_reports', function (Blueprint $table) {
+            $table->integer('id');
             $table->string('status')->index();
             $table->string('since');
             $table->string('before');
-            $table->string('imported');
             $table->timestamps();
+            $table->date('imported_at')->nullable();
+            $table->primary(array('id'));
         });
     }
 

--- a/database/migrations/2020_03_06_000200_create_rock_the_vote_reports_table.php
+++ b/database/migrations/2020_03_06_000200_create_rock_the_vote_reports_table.php
@@ -16,8 +16,8 @@ class CreateRockTheVoteReportsTable extends Migration
         Schema::create('rock_the_vote_reports', function (Blueprint $table) {
             $table->integer('id');
             $table->string('status')->index();
-            $table->string('since');
-            $table->string('before');
+            $table->string('since')->nullable();
+            $table->string('before')->nullable();
             $table->timestamps();
             $table->date('imported_at')->nullable();
             $table->primary(['id']);

--- a/database/migrations/2020_03_06_000200_create_rock_the_vote_reports_table.php
+++ b/database/migrations/2020_03_06_000200_create_rock_the_vote_reports_table.php
@@ -16,11 +16,12 @@ class CreateRockTheVoteReportsTable extends Migration
         Schema::create('rock_the_vote_reports', function (Blueprint $table) {
             $table->integer('id');
             $table->string('status')->index();
-            $table->string('since')->nullable();
-            $table->string('before')->nullable();
+            $table->dateTime('since')->nullable();
+            $table->dateTime('before')->nullable();
             $table->timestamps();
-            $table->date('imported_at')->nullable();
+            $table->dateTime('dispatched_at')->nullable();
             $table->primary(['id']);
+            $table->index(['status', 'dispatched_at']);
         });
     }
 

--- a/database/migrations/2020_03_06_000200_create_rock_the_vote_reports_table.php
+++ b/database/migrations/2020_03_06_000200_create_rock_the_vote_reports_table.php
@@ -20,7 +20,7 @@ class CreateRockTheVoteReportsTable extends Migration
             $table->string('before');
             $table->timestamps();
             $table->date('imported_at')->nullable();
-            $table->primary(array('id'));
+            $table->primary(['id']);
         });
     }
 

--- a/resources/views/pages/rock-the-vote-reports/create.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/create.blade.php
@@ -18,7 +18,7 @@
             </label>
             <div class="col-sm-9">
               <input type="text" class="form-control" name="since">
-              <small>e.g. 2020-02-28 12:00</small>
+              <small>e.g. 2020-02-28 12:00:00</small>
             </div>
         </div>
         <div class="form-group row">
@@ -27,7 +27,7 @@
             </label>
             <div class="col-sm-9">
               <input type="text" class="form-control" name="before">
-              <small>e.g. 2020-02-28 13:00</small>
+              <small>e.g. 2020-02-28 13:00:00</small>
             </div>
         </div>
         <div>

--- a/resources/views/pages/rock-the-vote-reports/create.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/create.blade.php
@@ -14,7 +14,7 @@
             </label>
             <div class="col-sm-9">
               <input type="text" class="form-control" name="since">
-              <small>e.g. 2020-02-07T05:13:27Z</small>
+              <small>e.g. 2019-12-01 12:00</small>
             </div>
         </div>
         <div class="form-group row">
@@ -23,15 +23,7 @@
             </label>
             <div class="col-sm-9">
               <input type="text" class="form-control" name="before">
-              <small>e.g. 2020-03-07T05:13:27Z</small>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="email" class="col-sm-3 col-form-label" required>
-                Email
-            </label>
-            <div class="col-sm-9">
-              <input type="text" class="form-control" name="email">
+              <small>e.g. 2019-12-01 12:00</small>
             </div>
         </div>
         <div>

--- a/resources/views/pages/rock-the-vote-reports/create.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/create.blade.php
@@ -14,7 +14,7 @@
             </label>
             <div class="col-sm-9">
               <input type="text" class="form-control" name="since">
-              <small>e.g. 2019-12-01 12:00</small>
+              <small>e.g. 2020-02-28 12:00</small>
             </div>
         </div>
         <div class="form-group row">
@@ -23,7 +23,7 @@
             </label>
             <div class="col-sm-9">
               <input type="text" class="form-control" name="before">
-              <small>e.g. 2019-12-01 12:00</small>
+              <small>e.g. 2019-02-28 13:00</small>
             </div>
         </div>
         <div>

--- a/resources/views/pages/rock-the-vote-reports/create.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/create.blade.php
@@ -17,6 +17,14 @@
             </div>
         </div>
         <div class="form-group row">
+            <label for="id" class="col-sm-3 col-form-label" required>
+                Status
+            </label>
+            <div class="col-sm-9">
+              <input type="text" class="form-control" name="status">
+            </div>
+        </div>
+        <div class="form-group row">
             <label for="since" class="col-sm-3 col-form-label" required>
                 Since
             </label>

--- a/resources/views/pages/rock-the-vote-reports/create.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/create.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+<div>
+    <h1>
+        Create Report
+    </h1>
+    <form method="POST" action="{{ route('reports.store') }}">
+        {{ csrf_field()}}
+        <div class="form-group row">
+            <label for="id" class="col-sm-3 col-form-label" required>
+                Report ID
+            </label>
+            <div class="col-sm-9">
+              <input type="text" class="form-control" name="id">
+            </div>
+        </div>
+        <div class="form-group row">
+            <label for="since" class="col-sm-3 col-form-label" required>
+                Since
+            </label>
+            <div class="col-sm-9">
+              <input type="text" class="form-control" name="since">
+            </div>
+        </div>
+        <div class="form-group row">
+            <label for="before" class="col-sm-3 col-form-label" required>
+                Before
+            </label>
+            <div class="col-sm-9">
+              <input type="text" class="form-control" name="before">
+            </div>
+        </div>
+        <div>
+            <input type="submit" class="btn btn-primary btn-lg" value="Create">
+        </div>
+    </form>
+</div>
+
+@stop

--- a/resources/views/pages/rock-the-vote-reports/create.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/create.blade.php
@@ -9,27 +9,12 @@
     <form method="POST" action="{{ route('reports.store') }}">
         {{ csrf_field()}}
         <div class="form-group row">
-            <label for="id" class="col-sm-3 col-form-label" required>
-                Report ID
-            </label>
-            <div class="col-sm-9">
-              <input type="text" class="form-control" name="id">
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="id" class="col-sm-3 col-form-label" required>
-                Status
-            </label>
-            <div class="col-sm-9">
-              <input type="text" class="form-control" name="status">
-            </div>
-        </div>
-        <div class="form-group row">
             <label for="since" class="col-sm-3 col-form-label" required>
                 Since
             </label>
             <div class="col-sm-9">
               <input type="text" class="form-control" name="since">
+              <small>e.g. 2020-02-07T05:13:27Z</small>
             </div>
         </div>
         <div class="form-group row">
@@ -38,6 +23,15 @@
             </label>
             <div class="col-sm-9">
               <input type="text" class="form-control" name="before">
+              <small>e.g. 2020-03-07T05:13:27Z</small>
+            </div>
+        </div>
+        <div class="form-group row">
+            <label for="email" class="col-sm-3 col-form-label" required>
+                Email
+            </label>
+            <div class="col-sm-9">
+              <input type="text" class="form-control" name="email">
             </div>
         </div>
         <div>

--- a/resources/views/pages/rock-the-vote-reports/create.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/create.blade.php
@@ -3,9 +3,13 @@
 @section('main_content')
 
 <div>
-    <h1>
-        Create Report
-    </h1>
+    <h1>Create Report</h1>
+    <p>
+        Use this form to create a Rock The Vote CSV report of voter registrations.
+    <p>
+    <p>
+        <strong>Note</strong>: It won't automatically be imported yet, you'll still need to find and download it from our Rock The Vote partner portal for now.
+    </p> 
     <form method="POST" action="{{ route('reports.store') }}">
         {{ csrf_field()}}
         <div class="form-group row">
@@ -23,7 +27,7 @@
             </label>
             <div class="col-sm-9">
               <input type="text" class="form-control" name="before">
-              <small>e.g. 2019-02-28 13:00</small>
+              <small>e.g. 2020-02-28 13:00</small>
             </div>
         </div>
         <div>

--- a/resources/views/pages/rock-the-vote-reports/show.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/show.blade.php
@@ -12,6 +12,11 @@
     <p>
         Total rows: <strong>{{$report->record_count}}</strong>
     </p>
+    @if ($report->status === 'building')
+    <p>
+        Progress: <strong>{{round(($report->current_index * 100) / $report->record_count)}}% </strong>(processed <strong>{{$report->current_index}}</strong> rows)
+    </p>
+    @endif
 </div>
 
 @stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,7 +18,9 @@ $router->post('import/{importType}', 'ImportFileController@store')->name('import
 
 Route::resource('import-files', 'ImportFileController', ['only' => ['index', 'show']]);
 
-Route::resource('rock-the-vote/reports', 'RockTheVoteReportController', ['only' => ['show']]);
+Route::resource('rock-the-vote/reports', 'RockTheVoteReportController', [
+  'except' => ['delete', 'update']
+]);
 
 Route::resource('users', 'UserController', ['only' => ['show']]);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,7 +19,7 @@ $router->post('import/{importType}', 'ImportFileController@store')->name('import
 Route::resource('import-files', 'ImportFileController', ['only' => ['index', 'show']]);
 
 Route::resource('rock-the-vote/reports', 'RockTheVoteReportController', [
-  'except' => ['delete', 'update']
+    'except' => ['delete', 'update']
 ]);
 
 Route::resource('users', 'UserController', ['only' => ['show']]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,7 +19,7 @@ $router->post('import/{importType}', 'ImportFileController@store')->name('import
 Route::resource('import-files', 'ImportFileController', ['only' => ['index', 'show']]);
 
 Route::resource('rock-the-vote/reports', 'RockTheVoteReportController', [
-    'except' => ['delete', 'update']
+    'except' => ['delete', 'update'],
 ]);
 
 Route::resource('users', 'UserController', ['only' => ['show']]);


### PR DESCRIPTION
### What's this PR do?

This pull request continues to climb the automated RTV import mountain, picking up from #126, #127 and adding a new `app/Services/RockTheVote` function, `createReport`,  that executes a [`POST /reports` API request](https://rock-the-vote.github.io/Voter-Registration-Tool-API-Docs/#reports). It also adds:

* A `rock_the_vote_reports` table, for keeping track of reports we've created and whether we need to import them (or already did)

* A web form at `/rock-the-vote/imports/create` to test the function by passing `since` and `before` parameters, which is what we'll need eventually for generating reports hourly

<img width="553" alt="Screen Shot 2020-03-07 at 12 36 30 PM" src="https://user-images.githubusercontent.com/1236811/76152079-52348a00-6070-11ea-9c76-794807a203f7.png">

### How should this be reviewed?

Can test creating a report via the webform, it won't affect much except adding another report to the list of reports in our Rock The Vote portal (Tej said this is a non-issue). Testing will be a bit trickier once we want to start importing these reports once created, but that's for another PR.

### Any background context you want to provide?

Next up will be starting on importing the report once it's status is `complete` (the statuses a report has before it's done are `queued`, `building`, and `merging`), making use of the `imported_at` field to determine which reports we need to import when completed.

### Relevant tickets

References [Pivotal #171656723](https://www.pivotaltracker.com/story/show/171656723).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
