### PR TITLE
Adds index of RTV reports, page titles

### DIFF
--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -63,4 +63,16 @@ class RockTheVoteReportController extends Controller
             'report' => app(RockTheVote::class)->getReportStatusById($id),
         ]);
     }
+
+    /**
+     * Display a listing of Rock The Vote reports.
+     *
+     * @return Response
+     */
+    public function index()
+    {
+        $data = RockTheVoteReport::orderBy('id', 'desc')->paginate(15);
+
+        return view('pages.rock-the-vote-reports.index', ['data' => $data]);
+    }
 }

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -13,7 +13,7 @@
                 @if (Auth::user())
                     <li @if (Request::is('import-files*')) class="active" @endif>
                         <a class="nav-item nav-link" href="{{  '/import-files'  }}">
-                            Import files
+                            Imports
                         </a>
                     </li>
                     <li @if (Request::is('failed-jobs*')) class="active" @endif>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -7,7 +7,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>@yield('title') | Chompy </title>
+        <title>@yield('title') | Chompy</title>
         <link rel="stylesheet" href="{{ mix('/css/app.css') }}">
         <link rel="icon" type="image/png" href="http://twooter.biz/Gifs/tonguecat.png">
     </head>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -7,7 +7,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>Chompy</title>
+        <title>@yield('title') | Chompy </title>
         <link rel="stylesheet" href="{{ mix('/css/app.css') }}">
         <link rel="icon" type="image/png" href="http://twooter.biz/Gifs/tonguecat.png">
     </head>

--- a/resources/views/pages/failed-jobs/index.blade.php
+++ b/resources/views/pages/failed-jobs/index.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.master')
 
+@section('title', 'Failed jobs')
+
 @section('main_content')
 
 <div>

--- a/resources/views/pages/failed-jobs/show.blade.php
+++ b/resources/views/pages/failed-jobs/show.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.master')
 
+@section('title', 'Failed job')
+
 @section('main_content')
 
 <div>

--- a/resources/views/pages/import-files/create.blade.php
+++ b/resources/views/pages/import-files/create.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.master')
 
+@section('title', 'Upload CSV')
+
 @section('main_content')
 
 <div>

--- a/resources/views/pages/import-files/index.blade.php
+++ b/resources/views/pages/import-files/index.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.master')
 
+@section('title', 'Imports')
+
 @section('main_content')
 
 <div>

--- a/resources/views/pages/import-files/show.blade.php
+++ b/resources/views/pages/import-files/show.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.master')
 
+@section('title', 'Import details');
+
 @section('main_content')
 
 <div>

--- a/resources/views/pages/rock-the-vote-reports/create.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/create.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.master')
 
+@section('title', 'Create Rock The Vote report')
+
 @section('main_content')
 
 <div>

--- a/resources/views/pages/rock-the-vote-reports/index.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/index.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+<div>
+    <table class="table">
+        <thead>
+          <tr class="row">
+            <th class="col-md-2">ID</th>
+            <th class="col-md-3">Since</th>
+            <th class="col-md-3">Before</th>
+            <th class="col-md-2">Status</th>
+            <th class="col-md-2">Created</th>
+          </tr>
+        </thead>
+        @foreach($data as $key => $report)
+            <tr class="row">
+              <td class="col-md-2">
+                <a href="/rock-the-vote/reports/{{$report->id}}">
+                  <strong>{{$report->id}}</strong>
+                </a>
+              </td>
+              <td class="col-md-3">
+                {{$report->since}}
+              </td> 
+              <td class="col-md-3">
+                {{$report->before}}
+              </td>
+              <td class="col-md-2">
+                {{$report->status}}
+              </td>
+              <td class="col-md-2">
+                {{$report->created_at}}
+              </td>    
+            </tr>
+        @endforeach
+    </table>
+    {{$data->links()}}
+</div>
+
+@stop

--- a/resources/views/pages/rock-the-vote-reports/index.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/index.blade.php
@@ -3,6 +3,7 @@
 @section('main_content')
 
 <div>
+    <h1>Rock The Vote Reports</h1>
     <table class="table">
         <thead>
           <tr class="row">

--- a/resources/views/pages/rock-the-vote-reports/index.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/index.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.master')
 
+@section('title', 'Rock The Vote reports')
+
 @section('main_content')
 
 <div>

--- a/resources/views/pages/rock-the-vote-reports/show.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/show.blade.php
@@ -2,7 +2,6 @@
 
 @section('title', 'Rock The Vote report')
 
-
 @section('main_content')
 
 <div>

--- a/resources/views/pages/rock-the-vote-reports/show.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/show.blade.php
@@ -1,5 +1,8 @@
 @extends('layouts.master')
 
+@section('title', 'Rock The Vote report')
+
+
 @section('main_content')
 
 <div>


### PR DESCRIPTION
### What's this PR do?

This pull request adds an index view at `/rock-the-vote/reports` to paginate through all RTV reports created from this Chompy instance (unfortunately, we only have one production RTV API key so it's a little bit of a free-for-all on which app could have generated a report)

It also adds customized `<title>` tags to page views to improve UX.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Coming up next is automating the import of a RTV report once it's created.

### Relevant tickets

References [Pivotal #171656723](https://www.pivotaltracker.com/story/show/171656723).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
