### PR TITLE
Cleanup RTV reports 

### DIFF
--- a/app/Http/Controllers/Web/Auth/LoginController.php
+++ b/app/Http/Controllers/Web/Auth/LoginController.php
@@ -27,7 +27,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/import/rock-the-vote';
+    protected $redirectTo = '/';
 
     /**
      * Where to redirect users after logout.

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -2,6 +2,7 @@
 
 namespace Chompy\Http\Controllers\Web;
 
+use Chompy\ImportType;
 use Illuminate\Http\Request;
 use Chompy\Services\RockTheVote;
 use Chompy\Models\RockTheVoteReport;
@@ -28,7 +29,9 @@ class RockTheVoteReportController extends Controller
      */
     public function create()
     {
-        return view('pages.rock-the-vote-reports.create');
+        return view('pages.rock-the-vote-reports.create', [
+            'config' => ImportType::getConfig(ImportType::$rockTheVote),
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -39,8 +39,8 @@ class RockTheVoteReportController extends Controller
     public function store(Request $request)
     {
         $this->validate($request, [
-            'since' => ['required'],
-            'before' => ['required'],
+            'since' => ['date_format:Y-m-d H:i:s'],
+            'before' => ['date_format:Y-m-d H:i:s'],
         ]);
 
         // Execute API request to create a new Rock The Vote Report.

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -42,8 +42,8 @@ class RockTheVoteReportController extends Controller
     public function store(Request $request)
     {
         $this->validate($request, [
-            'since' => ['date_format:Y-m-d H:i:s'],
-            'before' => ['date_format:Y-m-d H:i:s'],
+            'since' => 'required|date_format:Y-m-d H:i:s',
+            'before' => 'required|date_format:Y-m-d H:i:s',
         ]);
 
         // Execute API request to create a new Rock The Vote Report.

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -54,7 +54,7 @@ class RockTheVoteReportController extends Controller
 
         ImportRockTheVoteReport::dispatch(\Auth::user(), $report);
 
-        return redirect('rock-the-vote/reports/' . $report->id);
+        return redirect('rock-the-vote-reports/' . $report->id);
     }
 
     /**

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -33,7 +33,7 @@
                         </a>
                     </li>
                     <li @if (strpos(Request::path(), 'rock-the-vote') !== false)) class="active" @endif>
-                        <a class="nav-item nav-link" href="/rock-the-vote/reports/create">
+                        <a class="nav-item nav-link" href="/rock-the-vote-reports">
                             Rock The Vote
                         </a>
                     </li>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -8,7 +8,7 @@
                 <span class="icon-bar"></span>
             </button>
 
-            <a class="navbar-brand">Chompy</a>
+            <a class="navbar-brand" href="/">Chompy</a>
             <ul class="nav navbar-nav">
                 @if (Auth::user())
                     <li @if (Request::is('import-files*')) class="active" @endif>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -27,13 +27,13 @@
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 @if (Auth::user())
-                    <li @if (Request::path() === $emailSubscriptionPath) class="active" @endif>
-                        <a class="nav-item nav-link" href="{{  '/'.$emailSubscriptionPath }}">
+                    <li @if (Request::path() === "import/email-subscription") class="active" @endif>
+                        <a class="nav-item nav-link" href="/import/email-subscription">
                             Email subscription
                         </a>
                     </li>
                     <li @if (strpos(Request::path(), 'rock-the-vote') !== false)) class="active" @endif>
-                        <a class="nav-item nav-link" href="{{'/rock-the-vote/reports/create'}}">
+                        <a class="nav-item nav-link" href="/rock-the-vote/reports/create">
                             Rock The Vote
                         </a>
                     </li>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -33,7 +33,7 @@
                         </a>
                     </li>
                     <li @if (strpos(Request::path(), 'rock-the-vote') !== false)) class="active" @endif>
-                        <a class="nav-item nav-link" href="{{  '/'.$rockTheVotePath }}">
+                        <a class="nav-item nav-link" href="{{'/rock-the-vote/reports/create'}}">
                             Rock The Vote
                         </a>
                     </li>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -29,10 +29,7 @@
             </div>
         @endif
         <div class="container-fluid">
-            @include('components.nav', [
-                'emailSubscriptionPath' => 'import/'.\Chompy\ImportType::$emailSubscription,
-                'rockTheVotePath' => 'import/'.\Chompy\ImportType::$rockTheVote,
-            ])
+            @include('components.nav')
         </div>
 
         <div class="container">

--- a/resources/views/pages/import-files/index.blade.php
+++ b/resources/views/pages/import-files/index.blade.php
@@ -10,8 +10,8 @@
           <tr class="row">
             <th class="col-md-3">Created</th>
             <th class="col-md-3">Import type</th>
-            <th class="col-md-2">Row count</th>
-            <th class="col-md-4">Created by</th>
+            <th class="col-md-3">Row count</th>
+            <th class="col-md-3">Created by</th>
           </tr>
         </thead>
         @foreach($data as $key => $importFile)
@@ -23,19 +23,27 @@
               </td>
               <td class="col-md-3">
                 {{$importFile->import_type}}
-              </td> 
-              <td class="col-md-2">
-                {{$importFile->row_count}}
-              </td>
-              <td class="col-md-4">
-                {{$importFile->user_id ? $importFile->user_id : 'Console'}}
                 @if ($importFile->options)
                   <ul>
                   @foreach (json_decode($importFile->options) as $key => $value)
-                    <li>{{$key}}: <strong>{{$value}}</strong></li>
+                    @if ($key === 'report_id')
+                      <li>
+                        <a href="/rock-the-vote/reports/{{$value}}">
+                          Report <strong>#{{$value}}</strong>
+                        </a>
+                      </li>
+                    @else
+                      <li>{{$key}}: <strong>{{$value}}</strong></li>
+                    @endif
                   @endforeach
                   </ul>
                 @endif
+              </td> 
+              <td class="col-md-3">
+                {{$importFile->row_count}}
+              </td>
+              <td class="col-md-3">
+                {{$importFile->user_id ? $importFile->user_id : 'Console'}}
               </td>     
             </tr>
         @endforeach

--- a/resources/views/pages/import-files/index.blade.php
+++ b/resources/views/pages/import-files/index.blade.php
@@ -28,8 +28,8 @@
                   @foreach (json_decode($importFile->options) as $key => $value)
                     @if ($key === 'report_id')
                       <li>
-                        <a href="/rock-the-vote/reports/{{$value}}">
-                          Report <strong>#{{$value}}</strong>
+                        <a href="/rock-the-vote-reports/{{$value}}">
+                          <strong>#{{$value}}</strong>
                         </a>
                       </li>
                     @else

--- a/resources/views/pages/partials/rock-the-vote/create.blade.php
+++ b/resources/views/pages/partials/rock-the-vote/create.blade.php
@@ -1,11 +1,5 @@
-<div class="form-group">
-    <h1>Rock The Vote</h1>
-    <p class="lead">
-      Creates or updates users and their voter registration post per uploaded Rock The Vote CSV.
-    </p>
-    </p>
-</div>
-<h3>Users</h3>
+<h3>Import configuration</h3>
+<h4>Users</h4>
 <div class="form-group row">
     <label class="col-sm-3 col-form-label">Email subscription topics</label>
     <div class="col-sm-9">
@@ -42,7 +36,7 @@
         </small>
     </div>
 </div>
-<h3>Posts</h3>
+<h4>Posts</h4>
 <div class="form-group row">
     <label class="col-sm-3 col-form-label">Action ID</label>
     <div class="col-sm-9">

--- a/resources/views/pages/rock-the-vote-reports/create.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/create.blade.php
@@ -9,7 +9,7 @@
     <p>
         Use this form to create and import a new Rock The Vote report.
     <p>
-    <form method="POST" action="{{ route('reports.store') }}">
+    <form method="POST" action="{{ route('rock-the-vote-reports.store') }}">
         {{ csrf_field()}}
         <div class="form-group row">
             <label for="since" class="col-sm-3 col-form-label" required>

--- a/resources/views/pages/rock-the-vote-reports/create.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/create.blade.php
@@ -7,11 +7,8 @@
 <div>
     <h1>Create Report</h1>
     <p>
-        Use this form to create a Rock The Vote CSV report of voter registrations.
+        Use this form to create and import a new Rock The Vote report.
     <p>
-    <p>
-        <strong>Note</strong>: It won't automatically be imported yet, you'll still need to find and download it from our Rock The Vote partner portal for now.
-    </p> 
     <form method="POST" action="{{ route('reports.store') }}">
         {{ csrf_field()}}
         <div class="form-group row">

--- a/resources/views/pages/rock-the-vote-reports/create.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/create.blade.php
@@ -32,6 +32,8 @@
         <div>
             <input type="submit" class="btn btn-primary btn-lg" value="Create">
         </div>
+        <hr />
+        @include('pages.partials.rock-the-vote.create', ['config' => $config])
     </form>
 </div>
 

--- a/resources/views/pages/rock-the-vote-reports/index.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/index.blade.php
@@ -13,7 +13,7 @@
             <th class="col-md-3">Since</th>
             <th class="col-md-3">Before</th>
             <th class="col-md-2">Status</th>
-            <th class="col-md-2">Created</th>
+            <th class="col-md-2">Imported</th>
           </tr>
         </thead>
         @foreach($data as $key => $report)
@@ -33,7 +33,7 @@
                 {{$report->status}}
               </td>
               <td class="col-md-2">
-                {{$report->created_at}}
+                {{$report->dispatched_at}}
               </td>    
             </tr>
         @endforeach

--- a/resources/views/pages/rock-the-vote-reports/index.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/index.blade.php
@@ -5,7 +5,7 @@
 @section('main_content')
 
 <div>
-    <h1>Rock The Vote Reports</h1>
+    <h1>Rock The Vote Reports <small><a class="pull-right" href="/rock-the-vote-reports/create">Create</a></small></h1>
     <table class="table">
         <thead>
           <tr class="row">

--- a/resources/views/pages/rock-the-vote-reports/show.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/show.blade.php
@@ -6,7 +6,7 @@
 
 <div>
     <h1>
-        Report #{{$report->id}}
+        Report #{{$report->id}} <small>{{$report->row_count}} rows</small>
     </h1>
     <p>
         Since: <strong>{{$report->since}}</strong>
@@ -17,12 +17,13 @@
     <p>
         Status: <strong>{{$report->status}}</strong>
     </p>
-    <p>
-        Total rows: <strong>{{$report->row_count}}</strong>
-    </p>
     @if ($report->status === 'building')
     <p>
         Progress: <strong>{{$report->percentage}}% </strong>(processed <strong>{{$report->current_index}}</strong> rows)
+    </p>
+    @elseif ($report->status === 'complete')
+    <p>
+        Imported: <strong>{{$report->dispatched_at}}</strong>
     </p>
     @endif
     <hr />

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,7 @@ Route::resource('rock-the-vote/reports', 'RockTheVoteReportController', [
 Route::resource('users', 'UserController', ['only' => ['show']]);
 
 Route::get('/', function () {
-    return view('pages.home');
+    return \Auth::check() ? redirect('import-files') : view('pages.home');
 });
 
 // Authentication

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,7 +18,7 @@ $router->post('import/{importType}', 'ImportFileController@store')->name('import
 
 Route::resource('import-files', 'ImportFileController', ['only' => ['index', 'show']]);
 
-Route::resource('rock-the-vote/reports', 'RockTheVoteReportController', [
+Route::resource('rock-the-vote-reports', 'RockTheVoteReportController', [
     'except' => ['delete', 'update'],
 ]);
 

--- a/tests/Http/Web/RockTheVoteReportTest.php
+++ b/tests/Http/Web/RockTheVoteReportTest.php
@@ -16,9 +16,9 @@ class RockTheVoteReportTest extends TestCase
     public function testUnauthorized()
     {
         $response = $this->postJson('/rock-the-vote-reports', [
-                'since' => '2019-12-19 00:00:00',
-                'before' => '2020-02-19 00:00:00',
-            ]);
+            'since' => '2019-12-19 00:00:00',
+            'before' => '2020-02-19 00:00:00',
+        ]);
 
         $response->assertStatus(401);
     }
@@ -32,9 +32,9 @@ class RockTheVoteReportTest extends TestCase
     {
         $admin = \Chompy\User::forceCreate(['role' => 'admin']);
         $response = $this->be($admin)->postJson('/rock-the-vote-reports', [
-                'since' => null,
-                'before' => '2020-02-19 00:00:00',
-            ]);
+            'since' => null,
+            'before' => '2020-02-19 00:00:00',
+        ]);
 
         $response->assertStatus(422);
     }

--- a/tests/Http/Web/RockTheVoteReportTest.php
+++ b/tests/Http/Web/RockTheVoteReportTest.php
@@ -13,6 +13,22 @@ class RockTheVoteReportTest extends TestCase
      *
      * @return void
      */
+    public function testUnauthorized()
+    {
+        $user = \Chompy\User::forceCreate(['role' => 'user']);
+        $response = $this->be($user)->postJson('/rock-the-vote-reports', [
+                'since' => '2019-12-19 00:00:00',
+                'before' => '2020-02-19 00:00:00',
+            ]);
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * Test creating and importing a Rock The Vote Report via web.
+     *
+     * @return void
+     */
     public function testCreateRockTheReportFormSubmission()
     {
         Bus::fake();

--- a/tests/Http/Web/RockTheVoteReportTest.php
+++ b/tests/Http/Web/RockTheVoteReportTest.php
@@ -9,19 +9,34 @@ use Chompy\Jobs\ImportRockTheVoteReport;
 class RockTheVoteReportTest extends TestCase
 {
     /**
-     * Test creating and importing a Rock The Vote Report via web.
+     * Test for unauthorized requests.
      *
      * @return void
      */
     public function testUnauthorized()
     {
-        $user = \Chompy\User::forceCreate(['role' => 'user']);
-        $response = $this->be($user)->postJson('/rock-the-vote-reports', [
+        $response = $this->postJson('/rock-the-vote-reports', [
                 'since' => '2019-12-19 00:00:00',
                 'before' => '2020-02-19 00:00:00',
             ]);
 
         $response->assertStatus(401);
+    }
+
+    /**
+     * Test for invalid parameters.
+     *
+     * @return void
+     */
+    public function testCreateRockTheReportFormValidation()
+    {
+        $admin = \Chompy\User::forceCreate(['role' => 'admin']);
+        $response = $this->be($admin)->postJson('/rock-the-vote-reports', [
+                'since' => null,
+                'before' => '2020-02-19 00:00:00',
+            ]);
+
+        $response->assertStatus(422);
     }
 
     /**

--- a/tests/Http/Web/RockTheVoteReportTest.php
+++ b/tests/Http/Web/RockTheVoteReportTest.php
@@ -23,7 +23,7 @@ class RockTheVoteReportTest extends TestCase
         ]);
 
         $admin = \Chompy\User::forceCreate(['role' => 'admin']);
-        $response = $this->be($admin)->postJson('/rock-the-vote/reports', [
+        $response = $this->be($admin)->postJson('/rock-the-vote-reports', [
             'since' => '2019-12-19 00:00:00',
             'before' => '2020-02-19 00:00:00',
         ]);
@@ -35,6 +35,6 @@ class RockTheVoteReportTest extends TestCase
         });
 
         // Verify redirect to new Rock the Vote report.
-        $response->assertRedirect('/rock-the-vote/reports/17');
+        $response->assertRedirect('/rock-the-vote-reports/17');
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request takes care of a few cleanup tasks to finish up API integration:

* Adds form validation for DateTime input to create RTV report form, and includes the RTV import configuration template 

* Renames route to `rock-the-vote-reports` for restful readability, adds tests for 401, 422 errors

* Changes RTV nav link to `rock-the-vote-reports` index  instead of  the `import/rock-the-vote` CSV upload form (which still will exist, just not within navigation), simplifies template


### How should this be reviewed?

👀 

<img width="600" alt="Screen Shot 2020-03-13 at 2 18 25 PM" src="https://user-images.githubusercontent.com/1236811/76660190-8e1a9400-6535-11ea-84f8-671798c90555.png">

### Relevant tickets

Closes [Pivotal #171656723](https://www.pivotaltracker.com/story/show/171656723).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
