### PR TITLE
Refactors RTV report creation

### DIFF
--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -4,7 +4,6 @@ namespace Chompy\Http\Controllers\Web;
 
 use Chompy\ImportType;
 use Illuminate\Http\Request;
-use Chompy\Services\RockTheVote;
 use Chompy\Models\RockTheVoteReport;
 use Chompy\Http\Controllers\Controller;
 use Chompy\Jobs\ImportRockTheVoteReport;
@@ -46,11 +45,7 @@ class RockTheVoteReportController extends Controller
             'before' => 'required|date_format:Y-m-d H:i:s',
         ]);
 
-        // Execute API request to create a new Rock The Vote Report.
-        $apiResponse = app(RockTheVote::class)->createReport($request->all());
-
-        // Log our created report in the database, to keep track of reports requested.
-        $report = RockTheVoteReport::createFromApiResponse($apiResponse, $request['since'], $request['before']);
+        $report = RockTheVoteReport::createViaApi($request['since'], $request['before']);
 
         ImportRockTheVoteReport::dispatch(\Auth::user(), $report);
 

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -2,6 +2,7 @@
 
 namespace Chompy\Models;
 
+use Chompy\Services\RockTheVote;
 use Illuminate\Database\Eloquent\Model;
 
 class RockTheVoteReport extends Model
@@ -52,15 +53,19 @@ class RockTheVoteReport extends Model
     ];
 
     /**
-     * Logs a Rock The Vote Report that we've created via API request.
+     * Creates a Rock The Vote Report via API request and saves to storage.
      *
-     * @param object $response
      * @param datetime $since
      * @param datetime $before
      * @return RockTheVoteReport
      */
-    public static function createFromApiResponse($response, $since, $before)
+    public static function createViaApi($since = null, $before = null)
     {
+        $response = app(RockTheVote::class)->createReport([
+            'since' => $since,
+            'before' => $before,
+        ]);
+
         // Parse response to find the new Rock The Vote Report ID.
         $statusUrlParts = explode('/', $response->status_url);
         $reportId = $statusUrlParts[count($statusUrlParts) - 1];

--- a/tests/Unit/Model/RockTheVoteReportTest.php
+++ b/tests/Unit/Model/RockTheVoteReportTest.php
@@ -13,16 +13,17 @@ class RockTheVoteReportTest extends TestCase
      *
      * @return void
      */
-    public function testCreateFromApiResponseWithValidResponse()
+    public function testCreateViaApiWithValidResponse()
     {
-        $apiResponse = (object) [
+        $this->rockTheVoteMock->shouldReceive('createReport')->andReturn((object) [
             'status'=> 'queued',
             'status_url' => 'https://register.rockthevote.com/api/v4/registrant_reports/17',
-        ];
+        ]);
+
         $since = '2019-12-19 00:00:00';
         $before = '2020-02-19 00:00:00';
 
-        $report = RockTheVoteReport::createFromApiResponse($apiResponse, $since, $before);
+        $report = RockTheVoteReport::createViaApi($since, $before);
 
         $this->assertEquals($report->id, 17);
         $this->assertEquals($report->since, $since);
@@ -36,11 +37,13 @@ class RockTheVoteReportTest extends TestCase
      *
      * @return void
      */
-    public function testCreateFromApiResponseWithInvalidResponseType()
+    public function testCreateViaApiWithInvalidResponseType()
     {
+        $this->rockTheVoteMock->shouldReceive('createReport')->andReturn('test');
+
         $this->expectException(ErrorException::class);
 
-        RockTheVoteReport::createFromApiResponse('test', null, null);
+        RockTheVoteReport::createViaApi();
     }
 
     /**
@@ -48,14 +51,14 @@ class RockTheVoteReportTest extends TestCase
      *
      * @return void
      */
-    public function testCreateFromApiResponseWithMissingStatusUrl()
+    public function testCreateViaApiWithMissingStatusUrl()
     {
+        $this->rockTheVoteMock->shouldReceive('createReport')->andReturn((object) [
+            'status'=> 'queued',
+        ]);
+
         $this->expectException(ErrorException::class);
 
-        $apiResponse = (object) [
-            'status'=> 'queued',
-        ];
-
-        RockTheVoteReport::createFromApiResponse($apiResponse, null, null);
+        RockTheVoteReport::createViaApi();
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request renames the `createFromApiResponse` method to `createViaApi`, changing the function to execute the `POST /reports` request to RTV API, instead of expecting an API response as a parameter. 

We'll need to create a report from a console command to run our import hourly, so this PR makes the change to DRY executing the API request.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Opening this now before adding the code for the scheduled import job to help keep the PR's reviewable.

### Relevant tickets

References [Pivotal #171737459](https://www.pivotaltracker.com/story/show/171737459).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
