### PR TITLE
Increase overlapping interval for hourly reports

### DIFF
--- a/app/Console/Commands/ImportRockTheVoteCommand.php
+++ b/app/Console/Commands/ImportRockTheVoteCommand.php
@@ -33,8 +33,8 @@ class ImportRockTheVoteCommand extends Command
         $before = Carbon::now();
         $since = clone $before;
 
-        // ... and after an hour ago (adding two overlapping minutes to ensure we don't miss any within the internal).
-        $since->subHours(1)->subMinutes(2);
+        // ... and after an hour ago (adding 30 overlapping minutes to ensure we don't miss any within the internal).
+        $since->subHours(1)->subMinutes(30);
 
         info('Executing import command', ['since' => $since, 'before' => $before]);
 

--- a/tests/Console/ImportRockTheVoteCommandTest.php
+++ b/tests/Console/ImportRockTheVoteCommandTest.php
@@ -22,7 +22,7 @@ class ImportRockTheVoteCommandTest extends TestCase
         Bus::assertDispatched(CreateRockTheVoteReport::class, function ($job) use (&$startTime) {
             $params = $job->getParameters();
 
-            return $params['before'] == $startTime->toDateTimeString() && $params['since'] == $startTime->subHours(1)->subMinutes(2)->toDateTimeString();
+            return $params['before'] == $startTime->toDateTimeString() && $params['since'] == $startTime->subHours(1)->subMinutes(30)->toDateTimeString();
         });
     }
 }


### PR DESCRIPTION
### What's this PR do?

Now that the second automated import has run in production, I manually created a report between the last row of the 1st automated report  2020-03-18 13:28:36 and the last row of the 2nd report : 2020-03-18 13:43:07-- to see if we missed any records. This report generated 159 rows, which is very weird. There's also a disconnect between the dates I'm passing in the API and the dates returned in the report.

This PR increases the overlap time to 30 minutes just to be on the safe side, to make sure we don't miss any rows.

### How should this be reviewed?

👀 

### Any background context you want to provide?

⏳ 

### Relevant tickets

References [Pivotal #171737459](https://www.pivotaltracker.com/story/show/171737459).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
