### PR TITLE
Adds is_valid_mobile helper

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -31,7 +31,7 @@ class RockTheVoteRecord
         $this->email = $record['Email address'];
         $this->first_name = $record['First name'];
         $this->last_name = $record['Last name'];
-        $this->mobile = is_valid_mobile($record['Phone']) ? $record['Phone'] : null;
+        $this->mobile = isset($record['Phone']) && is_valid_mobile($record['Phone']) ? $record['Phone'] : null;
 
         // Voter registration details.
         $this->rtv_finish_with_state = $record['Finish with State'];

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -31,7 +31,7 @@ class RockTheVoteRecord
         $this->email = $record['Email address'];
         $this->first_name = $record['First name'];
         $this->last_name = $record['Last name'];
-        $this->mobile = $record['Phone'];
+        $this->mobile = is_valid_mobile($record['Phone']) ? $record['Phone'] : null;
 
         // Voter registration details.
         $this->rtv_finish_with_state = $record['Finish with State'];

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -35,3 +35,18 @@ function is_anonymous_mobile($mobile)
         '+8656696',
     ]);
 }
+
+/**
+ * Determines if a mobile number is valid.
+ *
+ * @TODO: Add phone number validation lib, or DRY this with Northstar validation through Gateway.
+ * @see https://git.io/Jvy0A
+ * For now, RTV is passing through a 000-000-0000 number that causes user creation to fail.
+ *
+ * @param string $mobile
+ * @return bool
+ */
+function is_valid_mobile($mobile)
+{
+    return $mobile != '000-000-0000';
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -42,6 +42,7 @@ function is_anonymous_mobile($mobile)
  * @TODO: Add phone number validation lib, or DRY this with Northstar validation through Gateway.
  * @see https://git.io/Jvy0A
  * For now, RTV is passing through a 000-000-0000 number that causes user creation to fail.
+ * @see https://github.com/DoSomething/chompy/pull/140
  *
  * @param string $mobile
  * @return bool

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests;
+
+use Tests\TestCase;
+
+class HelpersTest extends TestCase
+{
+    /**
+     * Test expected results for the minimalist is_valid_mobile helper.
+     *
+     * @return void
+     */
+    public function testIsValidMobile()
+    {
+        $this->assertEquals(is_valid_mobile('212-254-2390'), true);
+        $this->assertEquals(is_valid_mobile('000-000-0000'), false);
+    }
+}

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests;
 
-use Tests\TestCase;
-
 class HelpersTest extends TestCase
 {
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request adds a very scrappy first pass at a `is_valid_mobile` helper, checking for the value `000-000-0000`.  We received a registration with `000-000-0000` set as the mobile, which otherwise looks otherwise valid -- this should cause the failed job to succeed the next time we retry it.

<img width="600" alt="Screen Shot 2020-03-23 at 4 15 40 PM" src="https://user-images.githubusercontent.com/1236811/77371951-c08c7400-6d21-11ea-82d9-86b267e6ac7b.png">

### How should this be reviewed?

👀 

### Any background context you want to provide?

Can add more to this helper if it comes up, for now this is the only mobile number validation issue I've seen.


### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
