### PR TITLE
Save referrer_user_id for Rock The Vote referrals

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -71,7 +71,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
         if (! $existingPosts['data']) {
             $post = $rogue->createPost(array_merge(['northstar_id' => $user->id], $this->postData));
- 
+
             info('Created post', ['post' => $post['data']['id'], 'user' => $user->id]);
 
             return;

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -71,16 +71,18 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
         if (! $existingPosts['data']) {
             $post = $rogue->createPost(array_merge(['northstar_id' => $user->id], $this->postData));
-
-            info('Created post', ['user' => $user->id]);
+ 
+            info('Created post', ['post' => $post['data']['id'], 'user' => $user->id]);
 
             return;
         }
 
         $post = $existingPosts['data'][0];
+
         info('Found post', ['post' => $post['id'], 'user' => $user->id]);
 
         $newStatus = $this->getVoterRegistrationStatusChange($post['status'], $this->postData['status']);
+
         if ($newStatus) {
             $rogue->updatePost($post['id'], ['status' => $newStatus]);
         }

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -34,7 +34,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
         $this->record = new RockTheVoteRecord($record, $this->config);
         $this->userData = $this->record->userData;
         $this->postData = $this->record->postData;
-        $this->import_file_id = $importFileId;
+        $this->importFileId = $importFileId;
     }
 
     /**
@@ -62,7 +62,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
             $this->sendUserPasswordResetIfSubscribed($user);
         }
 
-        RockTheVoteLog::createFromRecord($this->record, $user, $this->import_file_id);
+        RockTheVoteLog::createFromRecord($this->record, $user, $this->importFileId);
 
         $existingPosts = $rogue->getPost([
             'action_id' => $this->postData['action_id'],
@@ -89,9 +89,11 @@ class ImportRockTheVoteRecord implements ShouldQueue
     }
 
     /**
-     * Check for user first by record user_id, next by email, last by mobile.
+     * Check for user first by id, next by email, last by mobile.
      *
-     * @param array $record
+     * @param string $id
+     * @param string $email
+     * @param string $mobile
      * @return NorthstarUser
      */
     private function getUser($id, $email, $mobile)

--- a/app/Models/RockTheVoteLog.php
+++ b/app/Models/RockTheVoteLog.php
@@ -46,7 +46,7 @@ class RockTheVoteLog extends Model
         return static::firstOrCreate([
             'import_file_id' => $importFileId,
             'finish_with_state' => $info['Tracking Source'],
-            'pre_registered' => 'test',//$info['Pre-Registered'],
+            'pre_registered' => $info['Pre-Registered'],
             'started_registration' => $info['Started registration'],
             'status' => $info['Status'],
             'tracking_source' => $info['Tracking Source'],

--- a/app/Models/RockTheVoteLog.php
+++ b/app/Models/RockTheVoteLog.php
@@ -41,13 +41,15 @@ class RockTheVoteLog extends Model
      */
     public static function createFromRecord(RockTheVoteRecord $record, NorthstarUser $user, $importFileId)
     {
+        $info = get_object_vars(json_decode($record->postData['details']));
+
         return static::firstOrCreate([
             'import_file_id' => $importFileId,
-            'finish_with_state' => $record->rtv_finish_with_state,
-            'pre_registered' => $record->rtv_pre_registered,
-            'started_registration' => $record->rtv_started_registration,
-            'status' => $record->rtv_status,
-            'tracking_source' => $record->rtv_tracking_source,
+            'finish_with_state' => $info['Tracking Source'],
+            'pre_registered' => 'test',//$info['Pre-Registered'],
+            'started_registration' => $info['Started registration'],
+            'status' => $info['Status'],
+            'tracking_source' => $info['Tracking Source'],
             'user_id' => $user->id,
         ]);
     }

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -49,21 +49,21 @@ class RockTheVoteRecord
             'action_id' => $config['post']['action_id'],
         ];
 
-        $trackingSource = $this->parseTrackingSource($record['Tracking Source']);
+        $referralCode = $this->parseReferralCode($record['Tracking Source']);
 
-        $this->userData['id'] = $trackingSource['user_id'];
-        $this->userData['referrer_user_id'] = $trackingSource['referrer_user_id'];
-        $this->postData['referrer_user_id'] = $trackingSource['referrer_user_id'];
+        $this->userData['id'] = $referralCode['user_id'];
+        $this->userData['referrer_user_id'] = $referralCode['referrer_user_id'];
+        $this->postData['referrer_user_id'] = $referralCode['referrer_user_id'];
     }
 
     /**
-     * Parses User ID or Referrer User ID from Tracking Source value.
-     * The Tracking Source value is manually added by editors into URL's, so check for typos.
+     * Parses User ID or Referrer User ID from input value.
+     * Editors manually enter this value as a URL query string, so we safety check for typos.
      *
      * @param string $referralCode
      * @return array
      */
-    public function parseTrackingSource($referralCode)
+    public function parseReferralCode($referralCode)
     {
         info('Parsing referral code: ' . $referralCode);
 

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -14,62 +14,51 @@ class RockTheVoteRecord
      */
     public function __construct($record, $config)
     {
-        // User PII.
-        $this->addr_street1 = $record['Home address'];
-        $this->addr_street2 = $record['Home unit'];
-        $this->addr_city = $record['Home city'];
-        $this->addr_state = $record['Home state'];
-        $this->addr_zip = $record['Home zip code'];
-        $this->email = $record['Email address'];
-        $this->first_name = $record['First name'];
-        $this->last_name = $record['Last name'];
-        $this->mobile = isset($record['Phone']) && is_valid_mobile($record['Phone']) ? $record['Phone'] : null;
-
-        // Voter registration details.
-        $this->rtv_finish_with_state = $record['Finish with State'];
-        $this->rtv_pre_registered = $record['Pre-Registered'];
-        $this->rtv_started_registration = $record['Started registration'];
-        $this->rtv_status = $record['Status'];
-        $this->rtv_tracking_source = $record['Tracking Source'];
-
-        $emailOptIn = $record['Opt-in to Partner email?'];
-        if ($emailOptIn) {
-            $this->email_subscription_status = str_to_boolean($emailOptIn);
-            if ($this->email_subscription_status) {
-                $this->email_subscription_topics = explode(',', $config['user']['email_subscription_topics']);
-            }
-        }
-
-        $this->user_source_detail = $config['user']['source_detail'];
-
+        $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);
         // Note: Not a typo, this column name does not have the trailing question mark.
-        $smsOptIn = $record['Opt-in to Partner SMS/robocall'];
-        if ($smsOptIn && $this->mobile) {
-            $this->sms_status = str_to_boolean($smsOptIn) ? 'active' : 'stop';
-        }
+        $smsOptIn = str_to_boolean($record['Opt-in to Partner SMS/robocall']);
         $rtvStatus = $this->parseVoterRegistrationStatus($record['Status'], $record['Finish with State']);
 
-        $this->voter_registration_status = Str::contains($rtvStatus, 'register') ? 'registration_complete' : $rtvStatus;
+        $this->userData = [
+            'addr_street1' => $record['Home address'],
+            'addr_street2' => $record['Home unit'],
+            'addr_city' => $record['Home city'],
+            'addr_zip' => $record['Home zip code'],
+            'email' => $record['Email address'],
+            'first_name' => $record['First name'],
+            'last_name' => $record['Last name'],
+            'mobile' => isset($record['Phone']) && is_valid_mobile($record['Phone']) ? $record['Phone'] : null,
+            'source_detail' => $config['user']['source_detail'],
+            'email_subscription_status' => $emailOptIn,
+            'email_subscription_topics' => $emailOptIn ? explode(',', $config['user']['email_subscription_topics']) : [],
+            'voter_registration_status' => Str::contains($rtvStatus, 'register') ? 'registration_complete' : $rtvStatus,
+        ];
 
-        $this->user_id = $this->parseUserId($record['Tracking Source']);
+        if ($smsOptIn && $this->userData['mobile']) {
+            $this->userData['sms_status'] = $smsOptin ? 'active' : 'stop';
+        }
 
-        $postConfig = $config['post'];
-        $this->post_source = $postConfig['source'];
-        $this->post_source_details = null;
-        $this->post_details = $this->parsePostDetails($record);
-        $this->post_status = $rtvStatus;
-        $this->post_type = $postConfig['type'];
-        $this->post_action_id = $postConfig['action_id'];
+        $this->postData = [
+            'source' => $config['post']['source'],
+            'source_details' => null,
+            'details' => $this->parsePostDetails($record),
+            'status' => $rtvStatus,
+            'type' => $config['post']['type'],
+            'action_id' => $config['post']['action_id'],
+        ];
+
+        $this->setUserId($record['Tracking Source']);
     }
 
     /**
-     * Parse existing user ID from referral code string.
+     * Parse existing user ID from referral code string.and add to userData.
      *
-     * @param  string $referralCode
-     * @return string
+     * @param string $referralCode
      */
-    public function parseUserId($referralCode)
+    public function setUserId($referralCode)
     {
+        $this->userData['id'] = null;
+
         info('Parsing referral code: ' . $referralCode);
 
         // Remove some nonsense that comes in front of the referral code sometimes
@@ -114,7 +103,9 @@ class RockTheVoteRecord
             }
         }
 
-        return isset($userId) ? $userId : null;
+        if (isset($userId)) {
+            $this->userData['id'] = $userId;
+        }
     }
 
     /**
@@ -158,6 +149,7 @@ class RockTheVoteRecord
             'Started registration',
             'Finish with State',
             'Status',
+            'Pre-Registered',
             'Home zip code',
         ];
 

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -28,10 +28,12 @@ class RockTheVoteRecord
             'first_name' => $record['First name'],
             'last_name' => $record['Last name'],
             'mobile' => isset($record['Phone']) && is_valid_mobile($record['Phone']) ? $record['Phone'] : null,
-            'source_detail' => $config['user']['source_detail'],
             'email_subscription_status' => $emailOptIn,
             'email_subscription_topics' => $emailOptIn ? explode(',', $config['user']['email_subscription_topics']) : [],
             'voter_registration_status' => Str::contains($rtvStatus, 'register') ? 'registration_complete' : $rtvStatus,
+            // Source is required in order to set the source detail.
+            'source' => config('services.northstar.client_credentials.client_id'),
+            'source_detail' => $config['user']['source_detail'],
         ];
 
         if ($smsOptIn && $this->userData['mobile']) {
@@ -51,7 +53,7 @@ class RockTheVoteRecord
     }
 
     /**
-     * Parse existing user ID from referral code string.and add to userData.
+     * Parse existing user ID from referral code string, and add to userData.
      *
      * @param string $referralCode
      */

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -96,6 +96,7 @@ class RockTheVoteRecord
 
             $key = strtolower($value[0]);
 
+            // Expected key: "user"
             if ($key === 'user' || $key === 'user_id' || $key === 'userid') {
                 $userId = $value[1];
             }
@@ -103,6 +104,8 @@ class RockTheVoteRecord
             /**
              * If referral parameter is set to true, the user parameter belongs to the referring
              * user, not the user that should be associated with this voter registration record.
+             *
+             * Expected key: "referral"
              */
             if (($key === 'referral' || $key === 'refferal') && str_to_boolean($value[1])) {
                 /**

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -17,14 +17,14 @@ class RockTheVoteRecordTest extends TestCase
     {
         return array_merge([
             'Home address' => $this->faker->streetAddress,
-            'Home unit' => null,
+            'Home unit' => $this->faker->randomDigit,
             'Home city' => $this->faker->city,
-            'Home state' => null,
-            'Home zip code' => null,
-            'Email address' => null,
-            'First name' => null,
-            'Last name' => null,
-            'Phone' => null,
+            'Home state' => $this->faker->state,
+            'Home zip code' => $this->faker->postcode,
+            'Email address' => $this->faker->email,
+            'First name' => $this->faker->firstName,
+            'Last name' => $this->faker->lastName,
+            'Phone' => $this->faker->phoneNumber,
             'Finish with State' => null,
             'Pre-Registered' => null,
             'Started registration' => null,
@@ -33,6 +33,37 @@ class RockTheVoteRecordTest extends TestCase
             'Opt-in to Partner email?' => null,
             'Opt-in to Partner SMS/robocall' => null,
         ], $data);
+    }
+
+    /**
+     * Test that userData and postData arrays are parsed from record.
+     *
+     * @return void
+     */
+    public function testSetsUserDataAndPostData()
+    {
+        $exampleRow = $this->getExampleRow();
+        $config = $this->getConfig();
+
+        $record = new RockTheVoteRecord($exampleRow, $this->getConfig());
+
+        $this->assertEquals($record->userData['addr_street1'], $exampleRow['Home address']);
+        $this->assertEquals($record->userData['addr_street2'], $exampleRow['Home unit']);
+        $this->assertEquals($record->userData['addr_city'], $exampleRow['Home city']);
+        $this->assertEquals($record->userData['email'], $exampleRow['Email address']);
+        $this->assertEquals($record->userData['first_name'], $exampleRow['First name']);
+        $this->assertEquals($record->userData['id'], null);
+        $this->assertEquals($record->userData['last_name'], $exampleRow['Last name']);
+        $this->assertEquals($record->userData['mobile'], $exampleRow['Phone']);
+        $this->assertEquals($record->userData['referrer_user_id'], null);
+        $this->assertEquals($record->userData['source'], config('services.northstar.client_credentials.client_id'));
+        $this->assertEquals($record->userData['source_detail'], $config['user']['source_detail']);
+
+        $this->assertEquals($record->postData['action_id'], $config['post']['action_id']);
+        $this->assertEquals($record->postData['source'], $config['post']['source']);
+        $this->assertEquals($record->postData['source_details'], null);
+        $this->assertEquals($record->postData['type'], $config['post']['type']);
+        $this->assertEquals($record->postData['referrer_user_id'], null);
     }
 
     /**

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -39,9 +39,9 @@ class RockTheVoteRecordTest extends TestCase
     {
         $record = new RockTheVoteRecord($this->getExampleRow(), ImportType::getConfig(ImportType::$rockTheVote));
 
-        $result = $record->parseUserId('user:58007c1242a0646e3a8b46b8,campaignID:8017,campaignRunID:8022,source:email,source_details:newsletter_bdaytrigger');
+        $record->setUserId('user:58007c1242a0646e3a8b46b8,campaignID:8017,campaignRunID:8022,source:email,source_details:newsletter_bdaytrigger');
 
-        $this->assertEquals($result, '58007c1242a0646e3a8b46b8');
+        $this->assertEquals($record->userData['id'], '58007c1242a0646e3a8b46b8');
     }
 
     /**
@@ -53,9 +53,9 @@ class RockTheVoteRecordTest extends TestCase
     {
         $record = new RockTheVoteRecord($this->getExampleRow(), ImportType::getConfig(ImportType::$rockTheVote));
 
-        $result = $record->parseUserId('campaignID:8017,campaignRunID:8022,source:email,source_details:newsletter_bdaytrigger');
+       $record->setUserId('campaignID:8017,campaignRunID:8022,source:email,source_details:newsletter_bdaytrigger');
 
-        $this->assertEquals($result, null);
+        $this->assertEquals($record->userData['id'], null);
     }
 
     /**
@@ -67,8 +67,8 @@ class RockTheVoteRecordTest extends TestCase
     {
         $record = new RockTheVoteRecord($this->getExampleRow(), ImportType::getConfig(ImportType::$rockTheVote));
 
-        $result = $record->parseUserId('user:5552aa34469c64ec7d8b715b,campaignID:7059,campaignRunID:8128,source:web,source_details:onlinedrivereferral,referral=true');
+        $record->setUserId('user:5552aa34469c64ec7d8b715b,campaignID:7059,campaignRunID:8128,source:web,source_details:onlinedrivereferral,referral=true');
 
-        $this->assertEquals($result, null);
+        $this->assertEquals($record->userData['id'], null);
     }
 }

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -53,7 +53,7 @@ class RockTheVoteRecordTest extends TestCase
     {
         $record = new RockTheVoteRecord($this->getExampleRow(), ImportType::getConfig(ImportType::$rockTheVote));
 
-       $record->setUserId('campaignID:8017,campaignRunID:8022,source:email,source_details:newsletter_bdaytrigger');
+        $record->setUserId('campaignID:8017,campaignRunID:8022,source:email,source_details:newsletter_bdaytrigger');
 
         $this->assertEquals($record->userData['id'], null);
     }


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the Rock The Vote import to include a `referrer_user_id` value when creating users and posts for voter registration referrals. It also refactors the import to build the payloads for creating users and posts in the `RockTheVoteRecord` class, to make things easier to test and hopefully more readable.

### How should this be reviewed?

👀 
I've been manually testing with a sample CSV to verify that users and posts are being created with `referrer_user_id` when the referral code is for a referral. I'd be happy to provide it to you if you'd like to pull down and run locally, but not necessary for review.

### Any background context you want to provide?

Definitely looking to add more tests, but will do so in a future PR to help keep this reviewable -- it's a bit larger than I'd prefer but was hard to split out the refactoring into separate PR's.

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/n/projects/2417735/stories/170775705).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
