### PR TITLE
Adds tests for subscriptions to RTV import

### DIFF
--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -12,11 +12,13 @@ class RockTheVoteRecord
      * @param array $record
      * @param array $config
      */
-    public function __construct($record, $config)
+    public function __construct($record, $config = null)
     {
+        if (! $config) {
+            $config = ImportType::getConfig(ImportType::$rockTheVote);
+        }
+
         $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);
-        // Note: Not a typo, this column name does not have the trailing question mark.
-        $smsOptIn = str_to_boolean($record['Opt-in to Partner SMS/robocall']);
         $rtvStatus = $this->parseVoterRegistrationStatus($record['Status'], $record['Finish with State']);
 
         $this->userData = [
@@ -36,8 +38,9 @@ class RockTheVoteRecord
             'source_detail' => $config['user']['source_detail'],
         ];
 
-        if ($smsOptIn && $this->userData['mobile']) {
-            $this->userData['sms_status'] = $smsOptin ? 'active' : 'stop';
+        if ($this->userData['mobile']) {
+            // Note: Not a typo, this column name does not have the trailing question mark.
+            $this->userData['sms_status'] = str_to_boolean($record['Opt-in to Partner SMS/robocall']) ? 'active' : 'stop';
         }
 
         $this->postData = [

--- a/tests/Jobs/RockTheVote/CreateRockTheVoteReportTest.php
+++ b/tests/Jobs/RockTheVote/CreateRockTheVoteReportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Console;
+namespace Tests\Jobs\RockTheVote;
 
 use Exception;
 use Tests\TestCase;

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteReportTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteReportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Http\Web;
+namespace Tests\Jobs\RockTheVote;
 
 use Tests\TestCase;
 use Chompy\User;

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -8,11 +8,6 @@ use Chompy\RockTheVoteRecord;
 
 class RockTheVoteRecordTest extends TestCase
 {
-    public function getConfig()
-    {
-        return ImportType::getConfig(ImportType::$rockTheVote);
-    }
-
     public function getExampleRow($data = [])
     {
         return array_merge([
@@ -30,8 +25,8 @@ class RockTheVoteRecordTest extends TestCase
             'Started registration' => null,
             'Status' => null,
             'Tracking Source' => null,
-            'Opt-in to Partner email?' => null,
-            'Opt-in to Partner SMS/robocall' => null,
+            'Opt-in to Partner email?' => 'Yes',
+            'Opt-in to Partner SMS/robocall' => 'Yes',
         ], $data);
     }
 
@@ -43,19 +38,22 @@ class RockTheVoteRecordTest extends TestCase
     public function testSetsUserDataAndPostData()
     {
         $exampleRow = $this->getExampleRow();
-        $config = $this->getConfig();
+        $config = ImportType::getConfig(ImportType::$rockTheVote);
 
-        $record = new RockTheVoteRecord($exampleRow, $this->getConfig());
+        $record = new RockTheVoteRecord($exampleRow, $config);
 
         $this->assertEquals($record->userData['addr_street1'], $exampleRow['Home address']);
         $this->assertEquals($record->userData['addr_street2'], $exampleRow['Home unit']);
         $this->assertEquals($record->userData['addr_city'], $exampleRow['Home city']);
         $this->assertEquals($record->userData['email'], $exampleRow['Email address']);
+        $this->assertEquals($record->userData['email_subscription_status'], true);
+        $this->assertEquals($record->userData['email_subscription_topics'], explode(',', $config['user']['email_subscription_topics']));
         $this->assertEquals($record->userData['first_name'], $exampleRow['First name']);
         $this->assertEquals($record->userData['id'], null);
         $this->assertEquals($record->userData['last_name'], $exampleRow['Last name']);
         $this->assertEquals($record->userData['mobile'], $exampleRow['Phone']);
         $this->assertEquals($record->userData['referrer_user_id'], null);
+        $this->assertEquals($record->userData['sms_status'], 'active');
         $this->assertEquals($record->userData['source'], config('services.northstar.client_credentials.client_id'));
         $this->assertEquals($record->userData['source_detail'], $config['user']['source_detail']);
 
@@ -64,6 +62,25 @@ class RockTheVoteRecordTest extends TestCase
         $this->assertEquals($record->postData['source_details'], null);
         $this->assertEquals($record->postData['type'], $config['post']['type']);
         $this->assertEquals($record->postData['referrer_user_id'], null);
+    }
+
+    /**
+     * Test that userData and postData arrays are parsed from record.
+     *
+     * @return void
+     */
+    public function testDidNotOptIn()
+    {
+        $exampleRow = $this->getExampleRow([
+            'Opt-in to Partner email?' => 'No',
+            'Opt-in to Partner SMS/robocall' => 'No',
+        ]);
+
+        $record = new RockTheVoteRecord($exampleRow);
+
+        $this->assertEquals($record->userData['email_subscription_status'], false);
+        $this->assertEquals($record->userData['email_subscription_topics'], []);
+        $this->assertEquals($record->userData['sms_status'], 'stop');
     }
 
     /**
@@ -77,7 +94,7 @@ class RockTheVoteRecordTest extends TestCase
 
         $record = new RockTheVoteRecord($this->getExampleRow([
             'Tracking Source' => $trackingSource,
-        ]), $this->getConfig());
+        ]));
 
         $this->assertEquals($record->userData['id'], '58007c1242a0646e3a8b46b8');
         $this->assertEquals($record->userData['referrer_user_id'], null);
@@ -95,7 +112,7 @@ class RockTheVoteRecordTest extends TestCase
 
         $record = new RockTheVoteRecord($this->getExampleRow([
             'Tracking Source' => $trackingSource,
-        ]), $this->getConfig());
+        ]));
 
         $this->assertEquals($record->userData['id'], null);
         $this->assertEquals($record->userData['referrer_user_id'], null);
@@ -113,7 +130,7 @@ class RockTheVoteRecordTest extends TestCase
 
         $record = new RockTheVoteRecord($this->getExampleRow([
             'Tracking Source' => $trackingSource,
-        ]), $this->getConfig());
+        ]));
 
         $this->assertEquals($record->userData['id'], null);
         $this->assertEquals($record->userData['referrer_user_id'], '5552aa34469c64ec7d8b715b');

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Http;
+namespace Tests\Unit;
 
 use Tests\TestCase;
 use Chompy\ImportType;

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -65,7 +65,7 @@ class RockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Test that userData and postData arrays are parsed from record.
+     * Test that user is not subscribed if they did not opt-in.
      *
      * @return void
      */
@@ -81,6 +81,42 @@ class RockTheVoteRecordTest extends TestCase
         $this->assertEquals($record->userData['email_subscription_status'], false);
         $this->assertEquals($record->userData['email_subscription_topics'], []);
         $this->assertEquals($record->userData['sms_status'], 'stop');
+    }
+
+    /**
+     * Test that user mobile is not set if invalid.
+     *
+     * @return void
+     */
+    public function testInvalidMobile()
+    {
+        $exampleRow = $this->getExampleRow([
+            'Phone' => '000-000-0000',
+            'Opt-in to Partner SMS/robocall' => 'Yes',
+        ]);
+
+        $record = new RockTheVoteRecord($exampleRow);
+
+        $this->assertEquals($record->userData['mobile'], null);
+        $this->assertFalse(isset($record->userData['sms_status']));
+    }
+
+    /**
+     * Test that user is not subscribed to SMS if mobile not provided.
+     *
+     * @return void
+     */
+    public function testMissingMobile()
+    {
+        $exampleRow = $this->getExampleRow([
+            'Phone' => '',
+            'Opt-in to Partner SMS/robocall' => 'Yes',
+        ]);
+
+        $record = new RockTheVoteRecord($exampleRow);
+
+        $this->assertEquals($record->userData['mobile'], null);
+        $this->assertFalse(isset($record->userData['sms_status']));
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request continues #142 in adding test coverage for the create user payload based on the "Opt-in" columns for email and SMS. Finds and fixes a bug in #142 for when users subscribe via SMS (which currently doesn't happen yet because we've hidden the Opt-in column for SMS on the RTV form -- but will happen soon when we bring it back)

### How should this be reviewed?

👀 

### Any background context you want to provide?

Next up is adding tests for `Chompy\Jobs\ImportRockTheVoteReport`, to have some coverage for when we should create a user/post vs update. 

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/story/show/170775705).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
