### PR TITLE
Adds SMS topic for new users + integration tests for updating existing users

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -149,7 +149,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
      * @param string $newStatus
      * @return bool
      */
-    private function shouldUpdateStatus($currentStatus, $newStatus)
+    public static function shouldUpdateStatus($currentStatus, $newStatus)
     {
         // List includes status values expected from RTV as well as
         // values potentially assigned from within Northstar.
@@ -178,7 +178,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
     {
         $payload = [];
 
-        if ($this->shouldUpdateStatus($user->voter_registration_status, $this->userData['voter_registration_status'])) {
+        if (self::shouldUpdateStatus($user->voter_registration_status, $this->userData['voter_registration_status'])) {
             $payload['voter_registration_status'] = $this->userData['voter_registration_status'];
         }
 
@@ -202,7 +202,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     private function updatePostIfChanged($post)
     {
-        if (! $this->shouldUpdateStatus($post['status'], $this->postData['status'])) {
+        if (! self::shouldUpdateStatus($post['status'], $this->postData['status'])) {
             info('No changes to update for post', ['post' => $post['id']]);
 
             return;

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -77,7 +77,15 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
         info('Found post', ['post' => $post['id'], 'user' => $user->id]);
 
-        $this->updatePostIfChanged($post);
+        if (! self::shouldUpdateStatus($post['status'], $this->postData['status'])) {
+            info('No changes to update for post', ['post' => $post['id']]);
+
+            return;
+        }
+
+        $rogue->updatePost($post['id'], ['status' => $this->postData['status']]);
+
+        info('Updated post', ['post' => $post['id'], 'status' => $this->postData['status']]);
     }
 
     /**
@@ -193,24 +201,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
         gateway('northstar')->asClient()->updateUser($user->id, $payload);
 
         info('Updated user', ['user' => $user->id, 'voter_registration_status' => $this->userData['voter_registration_status']]);
-    }
-
-    /**
-     * Update post with record data.
-     *
-     * @param array $post
-     */
-    private function updatePostIfChanged($post)
-    {
-        if (! self::shouldUpdateStatus($post['status'], $this->postData['status'])) {
-            info('No changes to update for post', ['post' => $post['id']]);
-
-            return;
-        }
-
-        $rogue->updatePost($post['id'], ['status' => $this->postData['status']]);
-
-        info('Updated post', ['post' => $post['id'], 'status' => $this->postData['status']]);
     }
 
     /**

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -174,7 +174,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
      *
      * @param object $user
      */
-    private function updateUserIfChanged($user)
+    public function updateUserIfChanged($user)
     {
         $payload = [];
 
@@ -251,6 +251,9 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function getParameters()
     {
-        return get_object_vars($this->record);
+        return [
+            'userData' => $this->userData,
+            'postData' => $this->postData,
+        ];
     }
 }

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -180,9 +180,9 @@ class ImportRockTheVoteRecord implements ShouldQueue
     /**
      * Update Northstar user with record data.
      *
-     * @param object $user
+     * @param NorthstarUser $user
      */
-    public function updateUserIfChanged($user)
+    private function updateUserIfChanged($user)
     {
         $payload = [];
 
@@ -206,7 +206,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
     /**
      * Send Northstar user a password reset email.
      *
-     * @param object $user
+     * @param NorthstarUser $user
      */
     private function sendUserPasswordResetIfSubscribed($user)
     {
@@ -241,9 +241,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function getParameters()
     {
-        return [
-            'userData' => $this->userData,
-            'postData' => $this->postData,
-        ];
+        return get_object_vars($this->record);
     }
 }

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -40,7 +40,10 @@ class RockTheVoteRecord
 
         if ($this->userData['mobile']) {
             // Note: Not a typo, this column name does not have the trailing question mark.
-            $this->userData['sms_status'] = str_to_boolean($record['Opt-in to Partner SMS/robocall']) ? 'active' : 'stop';
+            $smsOptIn = str_to_boolean($record['Opt-in to Partner SMS/robocall']);
+
+            $this->userData['sms_status'] = $smsOptIn ? 'active' : 'stop';
+            $this->userData['sms_subscription_topics'] = $smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
         }
 
         $this->postData = [

--- a/config/import.php
+++ b/config/import.php
@@ -41,6 +41,7 @@ return [
         ],
         'user' => [
             'email_subscription_topics' => env('ROCK_THE_VOTE_EMAIL_SUBSCRIPTION_TOPICS', 'community'),
+            'sms_subscription_topics' => env('ROCK_THE_VOTE_SMS_SUBSCRIPTION_TOPICS', 'voting'),
             'source_detail' => env('ROCK_THE_VOTE_USER_SOURCE_DETAIL', 'rock-the-vote'),
         ],
     ],

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -118,7 +118,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->mockGetNorthstarUser([
             'voter_registration_status' => 'registration_complete',
         ]);
-        $this->rogueMock->shouldNotReceive('createUser');
+        $this->northstarMock->shouldNotReceive('createUser');
         $this->northstarMock->shouldNotReceive('updateUser');
         $this->rogueMock->shouldReceive('getPost')->andReturn([
             'data' => [

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -120,4 +120,36 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job->updateUserIfChanged($user);
     }
+
+    /**
+     * Test that status should update when update value has higher priority than the current.
+     *
+     * @return void
+     */
+    public function testShouldUpdateStatus()
+    {
+        $priority = [
+            'uncertain',
+            'ineligible',
+            'unregistered',
+            'confirmed',
+            'register-OVR',
+            'register-form',
+            'registration_complete',
+        ];
+
+        for ($i = 0; $i < count($priority); $i++) {
+            $firstValue = $priority[$i];
+
+            for ($j = 0; $j < count($priority); $j++) {
+                $secondValue = $priority[$j];
+
+                if ($j > $i) {
+                    $this->assertTrue(ImportRockTheVoteRecord::shouldUpdateStatus($firstValue, $priority[$j]));
+                } else {
+                    $this->assertFalse(ImportRockTheVoteRecord::shouldUpdateStatus($firstValue, $priority[$j]));
+                }
+            }
+        }
+    }
 }

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -72,7 +72,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Test that user is updated if record indicates their voter registration status should change.
+     * Test that user is updated if their voter registration status should change.
      *
      * @return void
      */
@@ -93,6 +93,30 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->northstarMock->shouldReceive('updateUser')->with($user->id, [
             'voter_registration_status' => $params['userData']['voter_registration_status'],
         ]);
+
+        $job->updateUserIfChanged($user);
+    }
+
+    /**
+     * Test that user is not updated if their voter registration status should not change.
+     *
+     * @return void
+     */
+    public function testDoesNotUpdatesUserIfShouldNotChangeStatus()
+    {
+        $user = (object) [
+            'id' => $this->faker->northstar_id,
+            'voter_registration_status' => 'registration_complete',
+        ];
+
+        $job = new ImportRockTheVoteRecord($this->faker->rockTheVoteReportRow([
+            'Status' => 'Step 1',
+            'Finish with State' => 'No',
+        ]), $this->faker->randomDigitNotNull);
+
+        $params = $job->getParameters();
+
+        $this->northstarMock->shouldNotReceive('updateUser');
 
         $job->updateUserIfChanged($user);
     }

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -70,4 +70,30 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         ImportRockTheVoteRecord::dispatch($this->faker->rockTheVoteReportRow(), $this->faker->randomDigitNotNull);
     }
+
+    /**
+     * Test that user is updated if record indicates their voter registration status should change.
+     *
+     * @return void
+     */
+    public function testUpdatesUserIfShouldChangeStatus()
+    {
+        $user = (object) [
+            'id' => $this->faker->northstar_id,
+            'voter_registration_status' => 'uncertain',
+        ];
+
+        $job = new ImportRockTheVoteRecord($this->faker->rockTheVoteReportRow([
+            'Status' => 'Complete',
+            'Finish with State' => 'Yes',
+        ]), $this->faker->randomDigitNotNull);
+
+        $params = $job->getParameters();
+
+        $this->northstarMock->shouldReceive('updateUser')->with($user->id, [
+            'voter_registration_status' => $params['userData']['voter_registration_status'],
+        ]);
+
+        $job->updateUserIfChanged($user);
+    }
 }

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -32,6 +32,7 @@ class RockTheVoteRecordTest extends TestCase
         $this->assertEquals($record->userData['mobile'], $exampleRow['Phone']);
         $this->assertEquals($record->userData['referrer_user_id'], null);
         $this->assertEquals($record->userData['sms_status'], 'active');
+        $this->assertEquals($record->userData['sms_subscription_topics'], explode(',', $config['user']['sms_subscription_topics']));
         $this->assertEquals($record->userData['source'], config('services.northstar.client_credentials.client_id'));
         $this->assertEquals($record->userData['source_detail'], $config['user']['source_detail']);
 
@@ -67,6 +68,7 @@ class RockTheVoteRecordTest extends TestCase
         $this->assertEquals($record->userData['email_subscription_status'], false);
         $this->assertEquals($record->userData['email_subscription_topics'], []);
         $this->assertEquals($record->userData['sms_status'], 'stop');
+        $this->assertEquals($record->userData['sms_subscription_topics'], []);
     }
 
     /**
@@ -85,6 +87,7 @@ class RockTheVoteRecordTest extends TestCase
 
         $this->assertEquals($record->userData['mobile'], null);
         $this->assertFalse(isset($record->userData['sms_status']));
+        $this->assertFalse(isset($record->userData['sms_subscription_topics']));
     }
 
     /**
@@ -103,6 +106,7 @@ class RockTheVoteRecordTest extends TestCase
 
         $this->assertEquals($record->userData['mobile'], null);
         $this->assertFalse(isset($record->userData['sms_status']));
+        $this->assertFalse(isset($record->userData['sms_subscription_topics']));
     }
 
     /**

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -51,17 +51,17 @@ trait WithMocks
      *
      * @return user
      */
-    public function mockGetNorthstarUser()
+    public function mockGetNorthstarUser($data = [])
     {
-        $this->northstarMock->shouldReceive('getUser')->andReturnUsing(function ($type, $id) {
-            return new NorthstarUser([
+        $this->northstarMock->shouldReceive('getUser')->andReturnUsing(function ($type, $id) use (&$data) {
+            return new NorthstarUser(array_merge([
                 'id' => $type === 'id' ? $id : $this->faker->northstar_id,
                 'first_name' => $this->faker->firstName,
                 'last_name' => $this->faker->lastName,
                 'birthdate' => $this->faker->date,
                 'email' => $this->faker->email,
                 'mobile' => $this->faker->phoneNumber,
-            ]);
+            ], $data));
         });
     }
 

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -49,7 +49,8 @@ trait WithMocks
     /**
      * Mock the getUser Northstar call.
      *
-     * @return user
+     * @param array $data
+     * @return NorthstarUser
      */
     public function mockGetNorthstarUser($data = [])
     {
@@ -68,7 +69,7 @@ trait WithMocks
     /**
      * Mock the createUser Northstar call.
      *
-     * @return user
+     * @return NorthstarUser
      */
     public function mockCreateNorthstarUser()
     {


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `sms_subscription_topics` array value to the `RockTheVoteRecord->userData` payload if the user has opted in to SMS messaging, populating it for new users that are created via import. (refs https://github.com/DoSomething/northstar/pull/998)

It also adds a TODO for updating existing users with this field, and adds integration for the existing update logic before I start on modifying the sms subscriptions of existing users in a separate pull request - to help keep this reviewable.

### How should this be reviewed?

👀 

### Any background context you want to provide?

You'll see in the commits that I was going to add a function called `updatePostIfExists`, similar to `updateUserIfExists` -- but didn't like that I'd need to pass the `$rogue` class instance into the function to use it. Does anyone know the history of why we need the `Rogue` service at all, vs calling Gateway like we do for the Northstar calls? I couldn't figure out how the `$rogue` instance gets passed as an argument the job's `handle` function. cc @katiecrane @DFurnes 

### Relevant tickets

References [Pivotal #171848031](https://www.pivotaltracker.com/story/show/171848031).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
