### PR TITLE
Avoid double importing Rock the Vote records

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -52,7 +52,11 @@ class ImportRockTheVoteRecord implements ShouldQueue
             return $this->handleNewUser();
         }
 
-        // @TODO: Check if we've already imported this record before proceeding.
+        if (RockTheVoteLog::getByRecord($this->record, $user)) {
+            info('Skipping record that has already been imported', ['user' => $user->id, 'details' => $this->postData['details']]);
+
+            return;
+        }
 
         $this->updateUserIfChanged($user);
 
@@ -71,7 +75,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
             $this->updatePostIfChanged($post);
         }
 
-        // @TODO: Update log with imported_at.
+        RockTheVoteLog::createFromRecord($this->record, $user, $this->importFileId);
     }
 
     /**
@@ -136,7 +140,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
         $this->createPost($user);
 
-        // @TODO: Pass imported_at
         RockTheVoteLog::createFromRecord($this->record, $user, $this->importFileId);
 
         $this->sendUserPasswordResetIfSubscribed($user);

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -138,7 +138,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
     }
 
     /**
-     * Creates new user with record data.
+     * Creates new user with record user data.
      *
      * @return NorthstarUser
      */

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -53,7 +53,13 @@ class ImportRockTheVoteRecord implements ShouldQueue
         }
 
         if (RockTheVoteLog::getByRecord($this->record, $user)) {
-            info('Skipping record that has already been imported', ['user' => $user->id, 'details' => $this->postData['details']]);
+            $details = $this->record->getPostDetails();
+
+            info('Skipping record that has already been imported', [
+                'user' => $user->id,
+                'status' => $details['Status'],
+                'started_registration' => $details['Started registration'],
+            ]);
 
             return;
         }

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -220,6 +220,8 @@ class ImportRockTheVoteRecord implements ShouldQueue
     }
 
     /**
+     * Updates Rogue post with record data if it should be updated. 
+     *
      * @param array $post
      * @return void
      */

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -220,7 +220,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
     }
 
     /**
-     * Updates Rogue post with record data if it should be updated. 
+     * Updates Rogue post with record data if it should be updated.
      *
      * @param array $post
      * @return void

--- a/app/Models/RockTheVoteLog.php
+++ b/app/Models/RockTheVoteLog.php
@@ -41,7 +41,7 @@ class RockTheVoteLog extends Model
      */
     public static function createFromRecord(RockTheVoteRecord $record, NorthstarUser $user, $importFileId)
     {
-        $info = get_object_vars(json_decode($record->postData['details']));
+        $info = $record->getPostDetails();
 
         return self::create([
             'import_file_id' => $importFileId,
@@ -59,7 +59,7 @@ class RockTheVoteLog extends Model
      */
     public static function getByRecord(RockTheVoteRecord $record, NorthstarUser $user)
     {
-        $info = get_object_vars(json_decode($record->postData['details']));
+        $info = $record->getPostDetails();
 
         return self::where([
             'started_registration' => $info['Started registration'],

--- a/app/Models/RockTheVoteLog.php
+++ b/app/Models/RockTheVoteLog.php
@@ -43,7 +43,7 @@ class RockTheVoteLog extends Model
     {
         $info = get_object_vars(json_decode($record->postData['details']));
 
-        return static::firstOrCreate([
+        return static::create([
             'import_file_id' => $importFileId,
             'finish_with_state' => $info['Finish with State'],
             'pre_registered' => $info['Pre-Registered'],
@@ -52,5 +52,19 @@ class RockTheVoteLog extends Model
             'tracking_source' => $info['Tracking Source'],
             'user_id' => $user->id,
         ]);
+    }
+
+    /**
+     * Find a log for given record and user.
+     */
+    public static function getByRecord(RockTheVoteRecord $record, NorthstarUser $user)
+    {
+        $info = get_object_vars(json_decode($record->postData['details']));
+
+        return static::find([
+            'started_registration' => $info['Started registration'],
+            'status' => $info['Status'],
+            'user_id' => $user->id,
+        ])->first();
     }
 }

--- a/app/Models/RockTheVoteLog.php
+++ b/app/Models/RockTheVoteLog.php
@@ -43,7 +43,7 @@ class RockTheVoteLog extends Model
     {
         $info = get_object_vars(json_decode($record->postData['details']));
 
-        return static::create([
+        return self::create([
             'import_file_id' => $importFileId,
             'finish_with_state' => $info['Finish with State'],
             'pre_registered' => $info['Pre-Registered'],
@@ -61,7 +61,7 @@ class RockTheVoteLog extends Model
     {
         $info = get_object_vars(json_decode($record->postData['details']));
 
-        return static::find([
+        return self::where([
             'started_registration' => $info['Started registration'],
             'status' => $info['Status'],
             'user_id' => $user->id,

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -163,10 +163,9 @@ class RockTheVoteRecord
      */
     private function parsePostDetails($record)
     {
-        $config = ImportType::getConfig(ImportType::$rockTheVote);
         $result = [];
 
-        foreach ($config['post']['details'] as $key) {
+        foreach (config('import.rock_the_vote.post.details') as $key) {
             $result[$key] = $record[$key];
         }
 

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -163,21 +163,23 @@ class RockTheVoteRecord
      */
     private function parsePostDetails($record)
     {
-        $details = [];
+        $config = ImportType::getConfig(ImportType::$rockTheVote);
+        $result = [];
 
-        $importantKeys = [
-            'Tracking Source',
-            'Started registration',
-            'Finish with State',
-            'Status',
-            'Pre-Registered',
-            'Home zip code',
-        ];
-
-        foreach ($importantKeys as $key) {
-            $details[$key] = $record[$key];
+        foreach ($config['post']['details'] as $key) {
+            $result[$key] = $record[$key];
         }
 
-        return json_encode($details);
+        return json_encode($result);
+    }
+
+    /**
+     * Returns decoded post details as an array.
+     *
+     * @return array
+     */
+    public function getPostDetails()
+    {
+        return get_object_vars(json_decode($this->postData['details']));
     }
 }

--- a/config/import.php
+++ b/config/import.php
@@ -34,6 +34,15 @@ return [
             'action_id' => env('ROCK_THE_VOTE_POST_ACTION_ID', 954),
             'type' => env('ROCK_THE_VOTE_POST_TYPE', 'voter-reg'),
             'source' => env('ROCK_THE_VOTE_POST_SOURCE', 'rock-the-vote'),
+            // These correspond to column names in a Rock The Vote report.
+            'details' => [
+                'Tracking Source',
+                'Started registration',
+                'Finish with State',
+                'Status',
+                'Pre-Registered',
+                'Home zip code',
+            ],
         ],
         'reset' => [
             'enabled' => env('ROCK_THE_VOTE_RESET_ENABLED', 'true'),

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Faker\Generator;
 use Chompy\Models\RockTheVoteLog;
 use Chompy\Models\RockTheVoteReport;
@@ -9,7 +10,7 @@ $factory->define(RockTheVoteLog::class, function (Generator $faker) {
         'finish_with_state' => 'No',
         'import_file_id' => $this->faker->randomDigitNotNull,
         'pre_registered' => 'No',
-        'started_registration' => '2020-02-22 19:16:32 -0500',
+        'started_registration' => Carbon::now()->format('Y-m-d H:i:s O'),
         'status' => 'Step 1',
         'tracking_source' => 'ads',
         'user_id' => $this->faker->northstar_id,

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,11 +1,24 @@
 <?php
 
 use Faker\Generator;
+use Chompy\Models\RockTheVoteLog;
 use Chompy\Models\RockTheVoteReport;
+
+$factory->define(RockTheVoteLog::class, function (Generator $faker) {
+    return [
+        'finish_with_state' => 'No',
+        'import_file_id' => $this->faker->randomDigitNotNull,
+        'pre_registered' => 'No',
+        'started_registration' => '2020-02-22 19:16:32 -0500',
+        'status' => 'Step 1',
+        'tracking_source' => 'ads',
+        'user_id' => $this->faker->northstar_id,
+    ];
+});
 
 $factory->define(RockTheVoteReport::class, function (Generator $faker) {
     return [
-        'id' => $faker->randomNumber(2),
+        'id' => $this->faker->randomDigitNotNull,
         'status' => 'queued',
     ];
 });

--- a/database/faker/FakerRockTheVoteReportRow.php
+++ b/database/faker/FakerRockTheVoteReportRow.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Faker\Provider\Base;
 
 class FakerRockTheVoteReportRow extends Base
@@ -24,7 +25,7 @@ class FakerRockTheVoteReportRow extends Base
             'Phone' => $this->generator->phoneNumber,
             'Finish with State' => 'Yes',
             'Pre-Registered' => 'No',
-            'Started registration' => '2020-02-22 19:16:32 -0500',
+            'Started registration' => Carbon::now()->format('Y-m-d H:i:s O'),
             'Status' => 'Step 1',
             'Tracking Source' => 'ads',
             'Opt-in to Partner email?' => 'Yes',

--- a/database/migrations/2020_03_31_000000_add_unique_index_to_rock_the_vote_logs_table.php
+++ b/database/migrations/2020_03_31_000000_add_unique_index_to_rock_the_vote_logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUniqueIndexToRockTheVoteLogsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rock_the_vote_logs', function (Blueprint $table) {
+            $table->index(['user_id', 'status', 'started_registration']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rock_the_vote_logs', function (Blueprint $table) {
+            $table->dropIndex(['user_id', 'status', 'started_registration']);
+        });
+    }
+}

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -20,7 +20,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $importFileId = $this->faker->randomDigitNotNull;
 
         $this->northstarMock->shouldReceive('getUser')->andReturn(null);
-        $this->mockCreateNorthstarUser($userId);
+        $this->mockCreateNorthstarUser(['id' => $userId]);
         $this->northstarMock->shouldReceive('sendPasswordReset');
         $this->rogueMock->shouldReceive('getPost')->andReturn(null);
         $this->rogueMock->shouldReceive('createPost')->andReturn([

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -15,8 +15,12 @@ class ImportRockTheVoteRecordTest extends TestCase
      */
     public function testCreatesUserIfUserNotFound()
     {
+        $userId = $this->faker->northstar_id;
+        $row = $this->faker->rockTheVoteReportRow();
+        $importFileId = $this->faker->randomDigitNotNull;
+
         $this->northstarMock->shouldReceive('getUser')->andReturn(null);
-        $this->mockCreateNorthstarUser();
+        $this->mockCreateNorthstarUser($userId);
         $this->northstarMock->shouldReceive('sendPasswordReset');
         $this->rogueMock->shouldReceive('getPost')->andReturn(null);
         $this->rogueMock->shouldReceive('createPost')->andReturn([
@@ -25,7 +29,14 @@ class ImportRockTheVoteRecordTest extends TestCase
             ],
         ]);
 
-        ImportRockTheVoteRecord::dispatch($this->faker->rockTheVoteReportRow(), $this->faker->randomDigitNotNull);
+        ImportRockTheVoteRecord::dispatch($row, $importFileId);
+
+        $this->assertDatabaseHas('rock_the_vote_logs', [
+            'user_id' => $userId,
+            'status' => $row['Status'],
+            'started_registration' => $row['Started registration'],
+            'import_file_id' => $importFileId,
+        ]);
     }
 
     /**
@@ -35,7 +46,11 @@ class ImportRockTheVoteRecordTest extends TestCase
      */
     public function testDoesNotCreateUserIfUserFound()
     {
-        $this->mockGetNorthstarUser();
+        $userId = $this->faker->northstar_id;
+        $row = $this->faker->rockTheVoteReportRow();
+        $importFileId = $this->faker->randomDigitNotNull;
+
+        $this->mockGetNorthstarUser(['id' => $userId]);
         $this->northstarMock->shouldNotReceive('createUser');
         $this->northstarMock->shouldNotReceive('sendPasswordReset');
         $this->rogueMock->shouldReceive('getPost')->andReturn(null);
@@ -45,7 +60,14 @@ class ImportRockTheVoteRecordTest extends TestCase
             ],
         ]);
 
-        ImportRockTheVoteRecord::dispatch($this->faker->rockTheVoteReportRow(), $this->faker->randomDigitNotNull);
+        ImportRockTheVoteRecord::dispatch($row, $importFileId);
+
+        $this->assertDatabaseHas('rock_the_vote_logs', [
+            'user_id' => $userId,
+            'status' => $row['Status'],
+            'started_registration' => $row['Started registration'],
+            'import_file_id' => $importFileId,
+        ]);
     }
 
     /**
@@ -55,7 +77,11 @@ class ImportRockTheVoteRecordTest extends TestCase
      */
     public function testDoesNotCreateOrUpdatePostIfCompletedPostFound()
     {
-        $this->mockGetNorthstarUser();
+        $userId = $this->faker->northstar_id;
+        $row = $this->faker->rockTheVoteReportRow();
+        $importFileId = $this->faker->randomDigitNotNull;
+
+        $this->mockGetNorthstarUser(['id' => $userId]);
         $this->northstarMock->shouldNotReceive('createUser');
         $this->northstarMock->shouldNotReceive('sendPasswordReset');
         $this->rogueMock->shouldReceive('getPost')->andReturn([
@@ -69,7 +95,14 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->rogueMock->shouldNotReceive('createPost');
         $this->rogueMock->shouldNotReceive('updatePost');
 
-        ImportRockTheVoteRecord::dispatch($this->faker->rockTheVoteReportRow(), $this->faker->randomDigitNotNull);
+        ImportRockTheVoteRecord::dispatch($row, $importFileId);
+
+        $this->assertDatabaseHas('rock_the_vote_logs', [
+            'user_id' => $userId,
+            'status' => $row['Status'],
+            'started_registration' => $row['Started registration'],
+            'import_file_id' => $importFileId,
+        ]);
     }
 
     /**
@@ -81,6 +114,11 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $userId = $this->faker->northstar_id;
         $postId = $this->faker->randomDigitNotNull;
+        $row = $this->faker->rockTheVoteReportRow([
+            'Status' => 'Complete',
+            'Finish with State' => 'Yes',
+        ]);
+        $importFileId = $this->faker->randomDigitNotNull;
 
         $this->mockGetNorthstarUser([
             'id' => $userId,
@@ -103,10 +141,14 @@ class ImportRockTheVoteRecordTest extends TestCase
             'status' => 'register-OVR',
         ]);
 
-        ImportRockTheVoteRecord::dispatch($this->faker->rockTheVoteReportRow([
-            'Status' => 'Complete',
-            'Finish with State' => 'Yes',
-        ]), $this->faker->randomDigitNotNull);
+        ImportRockTheVoteRecord::dispatch($row, $importFileId);
+
+        $this->assertDatabaseHas('rock_the_vote_logs', [
+            'user_id' => $userId,
+            'status' => $row['Status'],
+            'started_registration' => $row['Started registration'],
+            'import_file_id' => $importFileId,
+        ]);
     }
 
     /**
@@ -116,7 +158,15 @@ class ImportRockTheVoteRecordTest extends TestCase
      */
     public function testDoesNotUpdatesUserIfShouldNotChangeStatus()
     {
+        $userId = $this->faker->northstar_id;
+        $row = $this->faker->rockTheVoteReportRow([
+            'Status' => 'Step 1',
+            'Finish with State' => 'No',
+        ]);
+        $importFileId = $this->faker->randomDigitNotNull;
+
         $this->mockGetNorthstarUser([
+            'id' => $userId,
             'voter_registration_status' => 'registration_complete',
         ]);
         $this->northstarMock->shouldNotReceive('createUser');
@@ -132,10 +182,14 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->rogueMock->shouldNotReceive('createPost');
         $this->rogueMock->shouldNotReceive('updatePost');
 
-        ImportRockTheVoteRecord::dispatch($this->faker->rockTheVoteReportRow([
-            'Status' => 'Step 1',
-            'Finish with State' => 'No',
-        ]), $this->faker->randomDigitNotNull);
+        ImportRockTheVoteRecord::dispatch($row, $importFileId);
+
+        $this->assertDatabaseHas('rock_the_vote_logs', [
+            'user_id' => $userId,
+            'status' => $row['Status'],
+            'started_registration' => $row['Started registration'],
+            'import_file_id' => $importFileId,
+        ]);
     }
 
     /**

--- a/tests/Unit/Model/RockTheVoteLogTest.php
+++ b/tests/Unit/Model/RockTheVoteLogTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Http;
+
+use Tests\TestCase;
+use Chompy\RockTheVoteRecord;
+use Chompy\Models\RockTheVoteLog;
+use DoSomething\Gateway\Resources\NorthstarUser;
+
+class RockTheVoteLogTest extends TestCase
+{
+    /**
+     * Test that getByRecord returns a RockTheVoteLog when record and user found.
+     *
+     * @return void
+     */
+    public function testGetByRecordWhenFound()
+    {
+        $user = new NorthstarUser(['id' => $this->faker->northstar_id]);
+        $row = $this->faker->rockTheVoteReportRow();
+        $record = new RockTheVoteRecord($row);
+
+        $log = factory(RockTheVoteLog::class)->create([
+            'user_id' => $user->id,
+            'started_registration' => $row['Started registration'],
+            'status' => $row['Status'],
+        ]);
+
+        $result = RockTheVoteLog::getByRecord($record, $user);
+
+        $this->assertEquals($log->user_id, $user->id);
+        $this->assertEquals($log->started_registration, $row['Started registration']);
+        $this->assertEquals($log->status, $row['Status']);
+    }
+
+    /**
+     * Test that getByRecord returns null when record and user not found.
+     *
+     * @return void
+     */
+    public function testGetByRecordWhenNotFound()
+    {
+        $user = new NorthstarUser(['id' => $this->faker->northstar_id]);
+        $record = new RockTheVoteRecord($this->faker->rockTheVoteReportRow());
+
+        $result = RockTheVoteLog::getByRecord($record, $user);
+
+        $this->assertEquals($result, null);
+    }
+}

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -215,4 +215,22 @@ class RockTheVoteRecordTest extends TestCase
         $this->assertEquals($record->userData['voter_registration_status'], 'ineligible');
         $this->assertEquals($record->postData['status'], 'ineligible');
     }
+
+    /**
+     * Test expected value for getPostDetails result.
+     *
+     * @return void
+     */
+    public function testGetPostDetails()
+    {
+        $config = ImportType::getConfig(ImportType::$rockTheVote);
+        $row = $this->faker->rockTheVoteReportRow();
+        $record = new RockTheVoteRecord($row);
+
+        $result = $record->getPostDetails();
+
+        foreach ($config['post']['details'] as $key) {
+            $this->assertEquals($result[$key], $row[$key]);
+        }
+    }
 }

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -223,13 +223,12 @@ class RockTheVoteRecordTest extends TestCase
      */
     public function testGetPostDetails()
     {
-        $config = ImportType::getConfig(ImportType::$rockTheVote);
         $row = $this->faker->rockTheVoteReportRow();
         $record = new RockTheVoteRecord($row);
 
         $result = $record->getPostDetails();
 
-        foreach ($config['post']['details'] as $key) {
+        foreach (config('import.rock_the_vote.post.details') as $key) {
             $this->assertEquals($result[$key], $row[$key]);
         }
     }

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -69,21 +69,21 @@ trait WithMocks
     /**
      * Mock the createUser Northstar call.
      *
-     * @param string $id
+     * @param array $data
      * @return NorthstarUser
      */
-    public function mockCreateNorthstarUser($id)
+    public function mockCreateNorthstarUser($data = [])
     {
         $this->northstarMock
             ->shouldReceive('createUser')
-            ->andReturn(new NorthstarUser([
-                'id' => $id ? $id : $this->faker->northstar_id,
+            ->andReturn(new NorthstarUser(array_merge([
+                'id' => $this->faker->northstar_id,
                 'first_name' => $this->faker->firstName,
                 'last_name' => $this->faker->lastName,
                 'birthdate' => $this->faker->date,
                 'email' => $this->faker->email,
                 'mobile' => $this->faker->phoneNumber,
-            ]));
+            ], $data)));
     }
 
     /**

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -69,14 +69,15 @@ trait WithMocks
     /**
      * Mock the createUser Northstar call.
      *
+     * @param string $id
      * @return NorthstarUser
      */
-    public function mockCreateNorthstarUser()
+    public function mockCreateNorthstarUser($id)
     {
         $this->northstarMock
             ->shouldReceive('createUser')
             ->andReturn(new NorthstarUser([
-                'id' => $this->faker->northstar_id,
+                'id' => $id ? $id : $this->faker->northstar_id,
                 'first_name' => $this->faker->firstName,
                 'last_name' => $this->faker->lastName,
                 'birthdate' => $this->faker->date,


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the RTV import to only process a record if it hasn't been logged in the `rock_the_vote_logs` table. 

### How should this be reviewed?

The code changes are pretty small, this PR mostly adds test coverage to ensure these changes work as expected. What's changed:

* Create the `rock_the_vote_logs` entry after the `ImportRockTheVoteRecord` job has finished all of its tasks (either creating user or getting existing user and checking for updates + creating post or getting existing post and checking for updates)

* Adds a `RockTheVoteLog::getByRecord` function to search for whether a row has been imported already

    * Adds a compound index to the `rock_the_vote_logs` table to optimize search

* Extracts creating and updating posts into smaller `createPost` and `updatePostIfChanged` functions to improve readability of the `handle` function

* Adds a `RockTheVoteRecord` helper, `getPostDetails` to easily find row details saved into a `post.details` string property 

### Any background context you want to provide?

It hasn't been a big deal to re-process a record thus far, because we only update a user or post if a given record has a `Status` column value with higher priority than the user's `voter_registration_status` field or their voter registration post's `status` field.

However, once we modify this job to update the SMS preferences for users we import -- it will be important to NOT re-import a row, as the user might unsubscribe from SMS by the time we re-import the row. Our automated import may end up fetching a row a second time, because we purposely look for rows 30 minutes before the last job finished -- in order to avoid potentially missing rows in between jobs (see #139). 

### Relevant tickets

Prep work for subscribing existing users in [Pivotal #171848124](https://www.pivotaltracker.com/story/show/171848124).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
