### PR TITLE
Update import_count for email subscription imports

### DIFF
--- a/app/Jobs/EmailSubscription/ImportEmailSubscription.php
+++ b/app/Jobs/EmailSubscription/ImportEmailSubscription.php
@@ -4,6 +4,7 @@ namespace Chompy\Jobs;
 
 use Exception;
 use Chompy\ImportType;
+use Chompy\Models\ImportFile;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -42,16 +43,17 @@ class ImportEmailSubscription implements ShouldQueue
      * Create a new job instance.
      *
      * @param array $record
-     * @param string $sourceDetail
-     * @param array $emailSubscriptionTopics
+     * @param ImportFile $importFile
+     * @param array $importOptions
      * @return void
      */
-    public function __construct($record, $sourceDetail, $emailSubscriptionTopic)
+    public function __construct($record, ImportFile $importFile, $importOptions)
     {
         $this->email = $record['email'];
         $this->first_name = isset($record['first_name']) ? $record['first_name'] : null;
-        $this->source_detail = $sourceDetail;
-        $this->email_subscription_topic = $emailSubscriptionTopic;
+        $this->source_detail = $importOptions['source_detail'];
+        $this->email_subscription_topic = $importOptions['email_subscription_topic'];
+        $this->importFile = $importFile;
     }
 
     /**
@@ -69,6 +71,8 @@ class ImportEmailSubscription implements ShouldQueue
             $user = $this->createUser();
             $this->sendUserPasswordReset($user);
         }
+
+        $this->importFile->incrementImportCount();
     }
 
     /**

--- a/app/Jobs/ImportFileRecords.php
+++ b/app/Jobs/ImportFileRecords.php
@@ -108,7 +108,7 @@ class ImportFileRecords implements ShouldQueue
             if ($this->importType === ImportType::$rockTheVote) {
                 ImportRockTheVoteRecord::dispatch($record, $importFile);
             } elseif ($this->importType === ImportType::$emailSubscription) {
-                ImportEmailSubscription::dispatch($record, $this->importOptions['source_detail'], $this->importOptions['email_subscription_topic']);
+                ImportEmailSubscription::dispatch($record, $importFile, $this->importOptions);
             }
             event(new LogProgress('', 'progress', ($offset / $this->totalRecords) * 100));
         }

--- a/resources/views/pages/import-files/index.blade.php
+++ b/resources/views/pages/import-files/index.blade.php
@@ -24,19 +24,7 @@
               <td class="col-md-3">
                 {{$importFile->import_type}}
                 @if ($importFile->options)
-                  <ul>
-                  @foreach (json_decode($importFile->options) as $key => $value)
-                    @if ($key === 'report_id')
-                      <li>
-                        <a href="/rock-the-vote-reports/{{$value}}">
-                          <strong>#{{$value}}</strong>
-                        </a>
-                      </li>
-                    @else
-                      <li>{{$key}}: <strong>{{$value}}</strong></li>
-                    @endif
-                  @endforeach
-                  </ul>
+                  @include('pages.partials.import-files.import-options', ['options' => $importFile->options])
                 @endif
               </td> 
               <td class="col-md-3">

--- a/resources/views/pages/import-files/show.blade.php
+++ b/resources/views/pages/import-files/show.blade.php
@@ -11,6 +11,9 @@
     <p>
         <strong>{{$importFile->import_type}}</strong>
     </p>
+    @if ($importFile->options)
+        @include('pages.partials.import-files.import-options', ['options' => $importFile->options])
+    @endif
     <p>
         This file had a total of {{$importFile->row_count}} rows: <strong>{{$importFile->import_count}} imported, {{$importFile->skip_count}} skipped</strong>.
     </p>

--- a/resources/views/pages/partials/import-files/import-options.blade.php
+++ b/resources/views/pages/partials/import-files/import-options.blade.php
@@ -1,0 +1,13 @@
+<ul>
+  @foreach (json_decode($options) as $key => $value)
+    @if ($key === 'report_id')
+      <li>
+        <a href="/rock-the-vote-reports/{{$value}}">
+          <strong>#{{$value}}</strong>
+        </a>
+      </li>
+    @else
+      <li>{{$key}}: <strong>{{$value}}</strong></li>
+    @endif
+  @endforeach
+</ul>

--- a/resources/views/pages/users/show.blade.php
+++ b/resources/views/pages/users/show.blade.php
@@ -8,7 +8,6 @@
         <a href="{{config('services.rogue.url') . '/users/' . $id}}">View user in Rogue</a>
     </p>
     <h3>Rock The Vote</h3>
-    <p><strong>Note:</strong> We didn't start saving this data locally until Feb 27, 2020.</p>
     @include('pages.partials.rock-the-vote.logs', ['user_id' => $id, 'rows' => $rows])
 </div>
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the TODO mentioned in #149 -- it updates our other file-based import for email subscriptions to populate the new `import_count` field, added to the `import_files` table in #149.

It also adds the import options to the `show` view of an ImportFile, using a new partial to DRY.

<img width="538" alt="Screen Shot 2020-04-01 at 12 56 17 PM" src="https://user-images.githubusercontent.com/1236811/78180849-34143c80-7418-11ea-9889-39002365c8bf.png">

Also modifies the user view to remove help text, which can be outdated if we purge the logs database.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Wanted to get this in before deploying #148 and #149 to avoid having any Email Subscription import files with a 0 value for their `import_count`, which would be confusing.

### Relevant tickets

Side effect of [Pivotal #171848124](https://www.pivotaltracker.com/story/show/171848124).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
