### PR TITLE
Adds contains_phone column to RTV logs

### DIFF
--- a/app/Models/RockTheVoteLog.php
+++ b/app/Models/RockTheVoteLog.php
@@ -14,6 +14,7 @@ class RockTheVoteLog extends Model
      * @var array
      */
     protected $fillable = [
+        'contains_phone',
         'finish_with_state',
         'import_file_id',
         'pre_registered',
@@ -44,6 +45,7 @@ class RockTheVoteLog extends Model
         $info = $record->getPostDetails();
 
         $rockTheVoteLog = self::create([
+            'contains_phone' => isset($record->userData['mobile']),
             'import_file_id' => $importFile->id,
             'finish_with_state' => $info['Finish with State'],
             'pre_registered' => $info['Pre-Registered'],

--- a/database/migrations/2020_04_02_000000_add_contains_phone_field_to_rock_the_vote_logs_table.php
+++ b/database/migrations/2020_04_02_000000_add_contains_phone_field_to_rock_the_vote_logs_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddContainsPhoneFieldToRockTheVoteLogsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rock_the_vote_logs', function (Blueprint $table) {
+            $table->boolean('contains_phone')->after('finish_with_state')->nullable();
+            $table->index(['user_id', 'contains_phone', 'started_registration'], 'user_registration_contains_phone');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rock_the_vote_logs', function (Blueprint $table) {
+            $table->dropColumn('contains_phone');
+            $table->dropIndex('user_registration_contains_phone');
+        });
+    }
+}

--- a/resources/views/pages/partials/rock-the-vote/logs.blade.php
+++ b/resources/views/pages/partials/rock-the-vote/logs.blade.php
@@ -4,9 +4,10 @@
             <th class="col-md-2">Started Registration</th>
             <th class="col-md-2">{{$user_id ? 'Import File' : 'User'}}</th>
             <th class="col-md-1">Status</th>
-            <th class="col-md-3">Tracking Source</th>
-            <th class="col-md-2">Finish With State</th>
-            <th class="col-md-2">Pre-Registered</th>
+            <th class="col-md-4">Tracking Source</th>
+            <th class="col-md-1">Finish With State</th>
+            <th class="col-md-1">Pre-Registered</th>
+            <th class="col-md-1">Contains Phone</th>
         </tr>
     </thead>
     @foreach($rows as $key => $row)
@@ -22,18 +23,21 @@
             <td class="col-md-1">
                 {{$row->status}}
             </td>
-            <td class="col-md-3">
+            <td class="col-md-4">
                 <ul>
                     @foreach(explode(',', $row->tracking_source) as $attribute)
                         <li>{{$attribute}}</li>
                     @endforeach
                 </ul>
             </td>
-            <td class="col-md-2">
+            <td class="col-md-1">
                 {{$row->finish_with_state}}
             </td>
-            <td class="col-md-2">
+            <td class="col-md-1">
                 {{$row->pre_registered}}
+            </td>
+            <td class="col-md-1">
+                {{$row->contains_phone ? 'Yes' : 'No'}}
             </td> 
         </tr>
     @endforeach

--- a/tests/Unit/Models/RockTheVoteLogTest.php
+++ b/tests/Unit/Models/RockTheVoteLogTest.php
@@ -15,16 +15,17 @@ class RockTheVoteLogTest extends TestCase
      *
      * @return void
      */
-    public function testCreateFromRecord()
+    public function testCreateFromRecordThatContainsPhone()
     {
         $user = new NorthstarUser(['id' => $this->faker->northstar_id]);
-        $row = $this->faker->rockTheVoteReportRow();
+        $row = $this->faker->rockTheVoteReportRow([]);
         $importFile = factory(ImportFile::class)->create([
             'import_count' => 5,
         ]);
 
         $log = RockTheVoteLog::createFromRecord(new RockTheVoteRecord($row), $user, $importFile);
 
+        $this->assertEquals($log->contains_phone, true);
         $this->assertEquals($log->finish_with_state, $row['Finish with State']);
         $this->assertEquals($log->import_file_id, $importFile->id);
         $this->assertEquals($log->pre_registered, $row['Pre-Registered']);
@@ -37,6 +38,24 @@ class RockTheVoteLogTest extends TestCase
             'id' => $importFile->id,
             'import_count' => 6,
         ]);
+    }
+
+    /**
+     * Test that false is saved for contains_phone if row does not contain phone.
+     *
+     * @return void
+     */
+    public function testCreateFromRecordThatDoesNotContainPhone()
+    {
+        $user = new NorthstarUser(['id' => $this->faker->northstar_id]);
+        $row = $this->faker->rockTheVoteReportRow([
+            'Phone' => null,
+        ]);
+        $importFile = factory(ImportFile::class)->create();
+
+        $log = RockTheVoteLog::createFromRecord(new RockTheVoteRecord($row), $user, $importFile);
+
+        $this->assertEquals($log->contains_phone, false);
     }
 
     /**

--- a/tests/Unit/Models/RockTheVoteLogTest.php
+++ b/tests/Unit/Models/RockTheVoteLogTest.php
@@ -18,7 +18,7 @@ class RockTheVoteLogTest extends TestCase
     public function testCreateFromRecordThatContainsPhone()
     {
         $user = new NorthstarUser(['id' => $this->faker->northstar_id]);
-        $row = $this->faker->rockTheVoteReportRow([]);
+        $row = $this->faker->rockTheVoteReportRow();
         $importFile = factory(ImportFile::class)->create([
             'import_count' => 5,
         ]);


### PR DESCRIPTION
### What's this PR do?

This pull request adds a boolean `contains_phone` field to `rock_the_vote_logs`, tracking whether or not a RTV row contains a value for the `Phone` field. This way, we can avoid potentially re-subscribing someone if they happen to unsubscribe during the voter registration process.

Example:

* Our hourly RTV import receives a row for Alice with status `Step 4` that has opted her in to SMS (phone field is filled out, as well as opting in to DS texts). We process this record, and send Alice a welcome text 📲 

* Alice receives our welcome text, unsubscribes by texting back STOP 🚫, and then continues to complete their voter registration

* In the next hourly import, we receive a new RTV row for Alice for status `Complete`, which will still contain the same phone field and opt-in field values per above. We need the ability to check for any previous updates for this registration that would have subscribed her, in order to avoid re-subscribing. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

The check for whether a user registration has already updated someone's SMS preferences will be to query `rock_the_vote_logs` for the user's `user_id`,  the `started_registration` datetime, and a true value for `contains_phone`. If a `rock_the_vote_logs` entry is found, we should not update the user's SMS subscription -- otherwise we're in the clear to update their Northstar profile (and will be saving a `rock_the_vote_log` with `contains_phone` to true, so we won't make any other changes during the current registration). 

I hope this makes sense, but please 💬 me should you have any ❓ 

### Relevant tickets

References [Pivotal #171848124](https://www.pivotaltracker.com/story/show/171848124).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
