### PR TITLE
Cleanup fetching posts in RTV import

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -12,6 +12,7 @@ use Chompy\Models\RockTheVoteLog;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use DoSomething\Gateway\Resources\NorthstarUser;
 
 class ImportRockTheVoteRecord implements ShouldQueue
 {
@@ -155,7 +156,8 @@ class ImportRockTheVoteRecord implements ShouldQueue
      * @param NorthstarUser $user
      * @return array
      */
-    private function getPost($user) {
+    public function getPost(NorthstarUser $user)
+    {
         $result = app(Rogue::class)->getPosts([
             'action_id' => $this->postData['action_id'],
             'northstar_id' => $user->id,

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -77,19 +77,10 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
         $this->updateUserIfChanged($user);
 
-        $existingPosts = $rogue->getPost([
-            'action_id' => $this->postData['action_id'],
-            'northstar_id' => $user->id,
-        ]);
-
-        if (! $existingPosts['data']) {
-            $this->createPost($user);
-        } else {
-            $post = $existingPosts['data'][0];
-
-            info('Found post', ['post' => $post['id'], 'user' => $user->id]);
-
+        if ($post = $this->getPost($user)) {
             $this->updatePostIfChanged($post);
+        } else {
+            $this->createPost($user);
         }
 
         RockTheVoteLog::createFromRecord($this->record, $user, $this->importFile);
@@ -156,6 +147,29 @@ class ImportRockTheVoteRecord implements ShouldQueue
         info('Created user', ['user' => $user->id]);
 
         return $user;
+    }
+
+    /**
+     * Returns post for user if exists.
+     *
+     * @param NorthstarUser $user
+     * @return array
+     */
+    private function getPost($user) {
+        $result = app(Rogue::class)->getPosts([
+            'action_id' => $this->postData['action_id'],
+            'northstar_id' => $user->id,
+        ]);
+
+        if (! $result['data']) {
+            return null;
+        }
+
+        $post = $result['data'][0];
+
+        info('Found post', ['post' => $post['id'], 'user' => $user->id]);
+
+        return $post;
     }
 
     /**

--- a/app/Services/Rogue.php
+++ b/app/Services/Rogue.php
@@ -45,20 +45,15 @@ class Rogue extends RestApiClient
     }
 
     /**
-     * Get a post from Rogue give a set of filters.
-     * TODO: Rename this as getPosts, or refactor it to return the first array item.
-     * @see https://github.com/DoSomething/chompy/pull/58/files#r258543126
+     * Executes posts index API request with given filters.
+     * @see https://github.com/DoSomething/rogue/blob/master/docs/endpoints/posts.md
      *
      * @param array $inputs - The filters to use to grab the post.
-     * @return array $post - The found post.
+     * @return array
      */
-    public function getPost($inputs)
+    public function getPosts($inputs)
     {
-        $post = $this->asClient()->get('v3/posts', [
-            'filter' => $inputs,
-        ]);
-
-        return $post;
+        return $this->asClient()->get('v3/posts', ['filter' => $inputs]);
     }
 
     /**

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -23,7 +23,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->northstarMock->shouldReceive('getUser')->andReturn(null);
         $this->mockCreateNorthstarUser(['id' => $userId]);
         $this->northstarMock->shouldReceive('sendPasswordReset');
-        $this->rogueMock->shouldReceive('getPost')->andReturn(null);
+        $this->rogueMock->shouldReceive('getPosts')->andReturn(null);
         $this->rogueMock->shouldReceive('createPost')->andReturn([
             'data' => [
                 'id' => $this->faker->randomDigitNotNull,
@@ -54,7 +54,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->mockGetNorthstarUser(['id' => $userId]);
         $this->northstarMock->shouldNotReceive('createUser');
         $this->northstarMock->shouldNotReceive('sendPasswordReset');
-        $this->rogueMock->shouldReceive('getPost')->andReturn(null);
+        $this->rogueMock->shouldReceive('getPosts')->andReturn(null);
         $this->rogueMock->shouldReceive('createPost')->andReturn([
             'data' => [
                 'id' => $this->faker->randomDigitNotNull,
@@ -85,7 +85,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->mockGetNorthstarUser(['id' => $userId]);
         $this->northstarMock->shouldNotReceive('createUser');
         $this->northstarMock->shouldNotReceive('sendPasswordReset');
-        $this->rogueMock->shouldReceive('getPost')->andReturn([
+        $this->rogueMock->shouldReceive('getPosts')->andReturn([
             'data' => [
                 0 => [
                     'id' => $this->faker->randomDigitNotNull,
@@ -126,7 +126,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             'voter_registration_status' => 'uncertain',
         ]);
         $this->northstarMock->shouldNotReceive('createUser');
-        $this->rogueMock->shouldReceive('getPost')->andReturn([
+        $this->rogueMock->shouldReceive('getPosts')->andReturn([
             'data' => [
                 0 => [
                     'id' => $postId,
@@ -172,7 +172,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $this->northstarMock->shouldNotReceive('createUser');
         $this->northstarMock->shouldNotReceive('updateUser');
-        $this->rogueMock->shouldReceive('getPost')->andReturn([
+        $this->rogueMock->shouldReceive('getPosts')->andReturn([
             'data' => [
                 0 => [
                     'id' => $this->faker->randomDigitNotNull,
@@ -212,7 +212,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
 
         $this->northstarMock->shouldNotReceive('updateUser');
-        $this->rogueMock->shouldNotReceive('getPost');
+        $this->rogueMock->shouldNotReceive('getPosts');
         $this->rogueMock->shouldNotReceive('createPost');
         $this->rogueMock->shouldNotReceive('updatePost');
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a [TODO](https://github.com/DoSomething/chompy/pull/58#discussion_r258543126) of renaming the `getPost` function to `getPosts` in our Rogue service, and uses it within a `getPost` function to the `ImportRockTheVoteRecord` job, adding tests to verify the filters passed to the `GET /v3/posts` request.

### How should this be reviewed?

👀 

### Any background context you want to provide?

It'll be handy to have this new `getPost` function within the  `ImportRockTheVoteRecord` job when we eventually support multiple voter registration posts, and will need to inspect the `details` of each post to determine whether we should create or update a post based on the `Started registration` column.

### Relevant tickets

Prep for  [Pivotal #171737617](https://www.pivotaltracker.com/story/show/171737617).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
