### PR TITLE
Update voter registration status values

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,5 @@ References [Pivotal #]().
 ### Checklist
 
 - [ ] This PR has been added to the relevant Pivotal card.
+- [ ] Documentation added for new features/changed endpoints.
 - [ ] Added appropriate feature/unit tests.

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -200,17 +200,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public static function shouldUpdateStatus($currentStatus, $newStatus)
     {
-        // List includes status values expected from RTV as well as
-        // values potentially assigned from within Northstar.
-        $statusHierarchy = [
-            'uncertain',
-            'ineligible',
-            'unregistered',
-            'confirmed',
-            'register-OVR',
-            'register-form',
-            'registration_complete',
-        ];
+        $statusHierarchy = config('import.rock_the_vote.status_hierarchy');
 
         $indexOfCurrentStatus = array_search($currentStatus, $statusHierarchy);
         $indexOfNewStatus = array_search($newStatus, $statusHierarchy);

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -144,15 +144,7 @@ class RockTheVoteRecord
             return str_to_boolean($rtvFinishWithState) ? 'register-OVR' : 'register-form';
         }
 
-        if (str_contains($rtvStatus, 'step')) {
-            return 'uncertain';
-        }
-
-        if ($rtvStatus === 'rejected' || $rtvStatus === 'under 18') {
-            return 'ineligible';
-        }
-
-        return '';
+        return str_replace(' ', '-', $rtvStatus);
     }
 
     /**

--- a/config/import.php
+++ b/config/import.php
@@ -48,6 +48,26 @@ return [
             'enabled' => env('ROCK_THE_VOTE_RESET_ENABLED', 'true'),
             'type' => env('ROCK_THE_VOTE_RESET_TYPE', 'rock-the-vote-activate-account'),
         ],
+        /**
+         * This list includes status values we import from Rock The Vote, values we once
+         * translated from Rock the Vote (e.g. uncertain, ineligible), or values that a user
+         * may set via the web (e.g. unregistered).
+         */
+        'status_hierarchy' => [
+            'uncertain',
+            'ineligible',
+            'under-18',
+            'rejected',
+            'unregistered',
+            'step-1',
+            'step-2',
+            'step-3',
+            'step-4',
+            'confirmed',
+            'register-OVR',
+            'register-form',
+            'registration_complete',
+        ],
         'user' => [
             'email_subscription_topics' => env('ROCK_THE_VOTE_EMAIL_SUBSCRIPTION_TOPICS', 'community'),
             'sms_subscription_topics' => env('ROCK_THE_VOTE_SMS_SUBSCRIPTION_TOPICS', 'voting'),

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -50,11 +50,17 @@ class ImportRockTheVoteRecordTest extends TestCase
     public function testDoesNotCreateUserIfUserFound()
     {
         $userId = $this->faker->northstar_id;
-        $row = $this->faker->rockTheVoteReportRow();
+        $row = $this->faker->rockTheVoteReportRow([
+            'Status' => 'Step 1',
+        ]);
         $importFile = factory(ImportFile::class)->create();
 
-        $this->mockGetNorthstarUser(['id' => $userId]);
+        $this->mockGetNorthstarUser([
+            'id' => $userId,
+            'voter_registration_status' => 'step-1',
+        ]);
         $this->northstarMock->shouldNotReceive('createUser');
+        $this->northstarMock->shouldNotReceive('updateUser');
         $this->northstarMock->shouldNotReceive('sendPasswordReset');
         $this->rogueMock->shouldReceive('getPosts')->andReturn(null);
         $this->rogueMock->shouldReceive('createPost')->andReturn([
@@ -84,14 +90,18 @@ class ImportRockTheVoteRecordTest extends TestCase
         $row = $this->faker->rockTheVoteReportRow();
         $importFile = factory(ImportFile::class)->create();
 
-        $this->mockGetNorthstarUser(['id' => $userId]);
+        $this->mockGetNorthstarUser([
+            'id' => $userId,
+            'voter_registration_status' => 'registration_complete',
+        ]);
         $this->northstarMock->shouldNotReceive('createUser');
+        $this->northstarMock->shouldNotReceive('updateUser');
         $this->northstarMock->shouldNotReceive('sendPasswordReset');
         $this->rogueMock->shouldReceive('getPosts')->andReturn([
             'data' => [
                 0 => [
                     'id' => $this->faker->randomDigitNotNull,
-                    'status' => 'registration_complete',
+                    'status' => 'register-form',
                 ],
             ],
         ]);

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -176,8 +176,8 @@ class RockTheVoteRecordTest extends TestCase
             'Finish with State' => 'No',
         ]));
 
-        $this->assertEquals($record->userData['voter_registration_status'], 'uncertain');
-        $this->assertEquals($record->postData['status'], 'uncertain');
+        $this->assertEquals($record->userData['voter_registration_status'], 'step-1');
+        $this->assertEquals($record->postData['status'], 'step-1');
 
         // Complete + Did not finish with state
         $record = new RockTheVoteRecord($this->faker->rockTheVoteReportRow([
@@ -203,8 +203,8 @@ class RockTheVoteRecordTest extends TestCase
             'Finish with State' => 'No',
         ]));
 
-        $this->assertEquals($record->userData['voter_registration_status'], 'ineligible');
-        $this->assertEquals($record->postData['status'], 'ineligible');
+        $this->assertEquals($record->userData['voter_registration_status'], 'rejected');
+        $this->assertEquals($record->postData['status'], 'rejected');
 
         // Under 18
         $record = new RockTheVoteRecord($this->faker->rockTheVoteReportRow([
@@ -212,8 +212,8 @@ class RockTheVoteRecordTest extends TestCase
             'Finish with State' => 'No',
         ]));
 
-        $this->assertEquals($record->userData['voter_registration_status'], 'ineligible');
-        $this->assertEquals($record->postData['status'], 'ineligible');
+        $this->assertEquals($record->userData['voter_registration_status'], 'under-18');
+        $this->assertEquals($record->postData['status'], 'under-18');
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the RTV import to save the same values we get from Rock The Vote if a registration is not complete, to better segment our voter registration messaging.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I asked the data team about these changes [in Slack](https://dosomething.slack.com/archives/C6J24ADQW/p1585938307002900), and got the green light to go ahead and make these changes.

### Relevant tickets

References [Pivotal #171737617](https://www.pivotaltracker.com/story/show/171737617).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
