### PR TITLE
Create voter-reg post per unique "Started registration"

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -167,11 +167,25 @@ class ImportRockTheVoteRecord implements ShouldQueue
             return null;
         }
 
-        $post = $result['data'][0];
+        $key = 'Started registration';
+        $recordPostDetails = $this->record->getPostDetails();
+        $recordStartedRegistration = $recordPostDetails[$key];
 
-        info('Found post', ['post' => $post['id'], 'user' => $user->id]);
+        foreach ($result['data'] as $post) {
+            if (! isset($post['details'])) {
+                continue;
+            }
 
-        return $post;
+            $details = json_decode($post['details']);
+
+            if ($details->{$key} === $recordStartedRegistration) {
+                info('Found post', ['post' => $post['id'], 'user' => $user->id]);
+
+                return $post;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -151,7 +151,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
     }
 
     /**
-     * Returns voter-reg post for given user and the record "Started registration", if exists.
+     * Returns a post for given user and the record "Started registration", if it exists.
      *
      * @param NorthstarUser $user
      * @return array

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -151,7 +151,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
     }
 
     /**
-     * Returns post for user if exists.
+     * Returns voter-reg post for given user and the record "Started registration", if exists.
      *
      * @param NorthstarUser $user
      * @return array
@@ -161,6 +161,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
         $result = app(Rogue::class)->getPosts([
             'action_id' => $this->postData['action_id'],
             'northstar_id' => $user->id,
+            'type' => config('import.rock_the_vote.post.type'),
         ]);
 
         if (! $result['data']) {

--- a/database/faker/FakerRockTheVoteReportRow.php
+++ b/database/faker/FakerRockTheVoteReportRow.php
@@ -34,7 +34,9 @@ class FakerRockTheVoteReportRow extends Base
     }
 
     /**
+     * Return a mock Started registration field value.
      *
+     * @return string
      */
     public function rockTheVoteStartedRegistration()
     {

--- a/database/faker/FakerRockTheVoteReportRow.php
+++ b/database/faker/FakerRockTheVoteReportRow.php
@@ -25,11 +25,19 @@ class FakerRockTheVoteReportRow extends Base
             'Phone' => $this->generator->phoneNumber,
             'Finish with State' => 'Yes',
             'Pre-Registered' => 'No',
-            'Started registration' => Carbon::now()->format('Y-m-d H:i:s O'),
+            'Started registration' => $this->rockTheVoteStartedRegistration(),
             'Status' => 'Step 1',
             'Tracking Source' => 'ads',
             'Opt-in to Partner email?' => 'Yes',
             'Opt-in to Partner SMS/robocall' => 'Yes',
         ], $data);
+    }
+
+    /**
+     *
+     */
+    public function rockTheVoteStartedRegistration()
+    {
+        return Carbon::now()->format('Y-m-d H:i:s O');
     }
 }

--- a/database/faker/FakerRockTheVoteReportRow.php
+++ b/database/faker/FakerRockTheVoteReportRow.php
@@ -25,7 +25,7 @@ class FakerRockTheVoteReportRow extends Base
             'Phone' => $this->generator->phoneNumber,
             'Finish with State' => 'Yes',
             'Pre-Registered' => 'No',
-            'Started registration' => $this->rockTheVoteStartedRegistration(),
+            'Started registration' => $this->daysAgoInRockTheVoteFormat(),
             'Status' => 'Step 1',
             'Tracking Source' => 'ads',
             'Opt-in to Partner email?' => 'Yes',
@@ -38,7 +38,7 @@ class FakerRockTheVoteReportRow extends Base
      *
      * @return string
      */
-    public function rockTheVoteStartedRegistration($numDaysToSubtract = 0)
+    public function daysAgoInRockTheVoteFormat($numDaysToSubtract = 0)
     {
         return Carbon::now()->subDays($numDaysToSubtract)->format('Y-m-d H:i:s O');
     }

--- a/database/faker/FakerRockTheVoteReportRow.php
+++ b/database/faker/FakerRockTheVoteReportRow.php
@@ -38,8 +38,8 @@ class FakerRockTheVoteReportRow extends Base
      *
      * @return string
      */
-    public function rockTheVoteStartedRegistration()
+    public function rockTheVoteStartedRegistration($numDaysToSubtract = 0)
     {
-        return Carbon::now()->format('Y-m-d H:i:s O');
+        return Carbon::now()->subDays($numDaysToSubtract)->format('Y-m-d H:i:s O');
     }
 }

--- a/database/faker/FakerRogueVoterRegPost.php
+++ b/database/faker/FakerRogueVoterRegPost.php
@@ -1,0 +1,26 @@
+<?php
+
+use Carbon\Carbon;
+use Faker\Provider\Base;
+
+class FakerRogueVoterRegPost extends Base
+{
+    /**
+     * Return a mock voter-reg post from Rogue.
+     *
+     * @param array $data
+     * @return array
+     */
+    public function rogueVoterRegPost($userId, $startedRegistration, $status)
+    {
+        return [
+            'id' => $this->generator->randomDigitNotNull,
+            'northstar_id' => $userId ? $userId : $this->generator->northstar_id,
+            'status' => $status,
+            'type' => 'voter-reg',
+            'details' => json_encode((object)[
+                'Started registration' => $startedRegistration,
+            ]),
+        ];
+    }
+}

--- a/database/faker/FakerRogueVoterRegPost.php
+++ b/database/faker/FakerRogueVoterRegPost.php
@@ -10,7 +10,7 @@ class FakerRogueVoterRegPost extends Base
      * @param array $data
      * @return array
      */
-    public function rogueVoterRegPost($data = [], $startedRegistration)
+    public function rogueVoterRegPost($data, $startedRegistration)
     {
         $result = array_merge([
             'id' => $this->generator->randomDigitNotNull,

--- a/database/faker/FakerRogueVoterRegPost.php
+++ b/database/faker/FakerRogueVoterRegPost.php
@@ -10,7 +10,7 @@ class FakerRogueVoterRegPost extends Base
      * @param array $data
      * @return array
      */
-    public function rogueVoterRegPost($data, $startedRegistration)
+    public function rogueVoterRegPost($data = [], $startedRegistration = null)
     {
         $result = array_merge([
             'id' => $this->generator->randomDigitNotNull,
@@ -20,7 +20,7 @@ class FakerRogueVoterRegPost extends Base
         ], $data);
 
         $result['details'] = json_encode((object) [
-            'Started registration' => $startedRegistration,
+            'Started registration' => $startedRegistration ? $startedRegistration : $this->generator->rockTheVoteStartedRegistration(),
         ]);
 
         return $result;

--- a/database/faker/FakerRogueVoterRegPost.php
+++ b/database/faker/FakerRogueVoterRegPost.php
@@ -16,7 +16,7 @@ class FakerRogueVoterRegPost extends Base
             'id' => $this->generator->randomDigitNotNull,
             'northstar_id' => $this->generator->northstar_id,
             'status' => 'step-1',
-            'type' => 'voter-reg',
+            'type' => config('import.rock_the_vote.post.type'),
         ], $data);
 
         $result['details'] = json_encode((object) [

--- a/database/faker/FakerRogueVoterRegPost.php
+++ b/database/faker/FakerRogueVoterRegPost.php
@@ -20,7 +20,7 @@ class FakerRogueVoterRegPost extends Base
         ], $data);
 
         $result['details'] = json_encode((object) [
-            'Started registration' => $startedRegistration ? $startedRegistration : $this->generator->rockTheVoteStartedRegistration(),
+            'Started registration' => $startedRegistration ? $startedRegistration : $this->generator->daysAgoInRockTheVoteFormat(),
         ]);
 
         return $result;

--- a/database/faker/FakerRogueVoterRegPost.php
+++ b/database/faker/FakerRogueVoterRegPost.php
@@ -1,6 +1,5 @@
 <?php
 
-use Carbon\Carbon;
 use Faker\Provider\Base;
 
 class FakerRogueVoterRegPost extends Base
@@ -11,16 +10,19 @@ class FakerRogueVoterRegPost extends Base
      * @param array $data
      * @return array
      */
-    public function rogueVoterRegPost($userId, $startedRegistration, $status)
+    public function rogueVoterRegPost($data = [], $startedRegistration)
     {
-        return [
+        $result = array_merge([
             'id' => $this->generator->randomDigitNotNull,
-            'northstar_id' => $userId ? $userId : $this->generator->northstar_id,
-            'status' => $status,
+            'northstar_id' => $this->generator->northstar_id,
+            'status' => 'step-1',
             'type' => 'voter-reg',
-            'details' => json_encode((object)[
-                'Started registration' => $startedRegistration,
-            ]),
-        ];
+        ], $data);
+
+        $result['details'] = json_encode((object) [
+            'Started registration' => $startedRegistration,
+        ]);
+
+        return $result;
     }
 }

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -6,7 +6,7 @@ We import CSVs from Rock The Vote (RTV) to upsert users and their `voter-reg` po
 
 The import will upsert a `voter-reg` type post for each unique "Started registration" datetime we receive for the user -- saving it to an action we set via config variable. This import action is changed each election year, in order to track user registrations per election.
 
-If a user registers to vote twice in 2020 (e.g. change of address), two `voter-reg` posts will be upserted for the user and this year's action. Prior to changes made in April 2020, the import would upsert a single post for all registrations for an action ID (e.g registering to vote twice in 2018 resulted in a single `voter-reg` post).
+If a user registers to vote twice in 2020 (e.g. change of address), two `voter-reg` posts will be upserted for the user and this year's action. Prior to [changes made in April 2020](https://github.com/DoSomething/chompy/pull/154), the import would upsert a single post for all registrations for an action ID (e.g registering to vote twice in 2018 resulted in a single `voter-reg` post).
 
 ## Voter Registration Status
 
@@ -16,7 +16,7 @@ As of [April 2020](https://github.com/DoSomething/chompy/pull/153), we save the 
 
 - `register-OVR` - User completed the registration form on their state's Online Voter Registration platform (`Finish with State` is `Yes`)
 
-We count `voter-reg` posts with these two `register-*` statuses as registrations (and reportbacks) within reporting.
+We count `voter-reg` posts with these two `register-*` statuses as registrations (and reportbacks) within reporting. We also count the historical `confirmed` status imported from TurboVote as a registration.
 
 The other status values returned from are:
 

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -58,7 +58,7 @@ Because RTV CSVs may contain multiple records _for a single user_, we use the fo
 - `register-OVR`
 - `register-form`
 
-For example: If a user has a `confirmed` status already from a TV import, and the RTV file suggests that it should be `step-1`, do not update.
+For example: If a user has a `confirmed` status already from a previous TurboVote import, and the RTV file suggests that it should be `step-1`, do not update.
 
 We’ve established this hierarchy because each time a user interacts with the RTV form, a new row is created in the CSV. There are the edge cases when a user is chased to finish their registration that they would be interacting with the same row (thus the "steps"). Here’s one example:
 
@@ -91,8 +91,6 @@ So the full hierarchy order taken into account when updating the profile from lo
 - `confirmed`
 - `registration_complete`
 
-```
-
 ### Dealing with Non-Member Registrants
 
 If the referral column doesn't have a NS ID, we should do what we do with the TV import.
@@ -112,7 +110,6 @@ We've added `referral=true` to the link so that we can know to not attribute the
 
 If the referral column has `referral=true` in it, then proceed with the logic with dealing w/ non-member registrants above.
 
-
 ## Notes
 
 - Data uses the post `details` to determine `source` and `source_detail` used in voter registration reporting.
@@ -122,4 +119,3 @@ If the referral column has `referral=true` in it, then proceed with the logic wi
 - In early iterations of the import, we would pass Campaign/Run IDs as parameters within the referral code to use when upsert a `voter-reg` post.
 - If a user shares their UTM'ed URL with other people, there could be duplicate referral codes but associated with different registrants:
   See a [screenshot](https://cl.ly/0v210N283y2X) of what this data looks like (note: the user depicted in this spreadsheet is fake.)
-```

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -4,11 +4,9 @@ We import CSVs from Rock The Vote (RTV) to upsert users and their `voter-reg` po
 
 ## Overview
 
-The import is coded to upsert a single `voter-reg` type post for a user voter registration -- saving it to an action we set via config variable. This import action is changed each election year, in order to track user registrations per election.
+The import will upsert a `voter-reg` type post for each unique "Started registration" datetime we receive for the user -- saving it to an action we set via config variable. This import action is changed each election year, in order to track user registrations per election.
 
-For example, if a user registered to vote through DS in 2016, 2018, and 2020, they will have three different posts created because our import was configured for three different Action IDs in each of those election years.
-
-As another example, if a user registers to vote twice in 2020 (e.g. change of address), a single post is upserted for this year's action (two posts are not created).
+If a user registers to vote twice in 2020 (e.g. change of address), two `voter-reg` posts will be upserted for the user and this year's action. Prior to changes made in April 2020, the import would upsert a single post for all registrations for an action ID (e.g registering to vote twice in 2018 resulted in a single `voter-reg` post).
 
 ## Voter Registration Status
 
@@ -42,7 +40,7 @@ From [RTV docs](https://www.rockthevote.org/programs-and-partner-resources/tech-
 
 ### Status Hierarchy
 
-Because RTV CSVs may contain multiple records _for a single user_, we use the following hierarchy to determine which status should be reported on their Rogue post if a user post already exists for the import Action:
+Because RTV CSVs may contain multiple records _for a single user_, we use the following hierarchy to determine which status should be reported on their Rogue post if a user post already exists for the import Action and its `Started registration` datetime.
 
 1. `register-form`
 2. `register-OVR`

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -180,7 +180,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             'Status' => 'Step 1',
             'Finish with State' => 'No',
         ]);
-        $existingCompletedPost = $this->faker->rogueVoterRegPost([
+        $olderExistingCompletedPost = $this->faker->rogueVoterRegPost([
             'northstar_id' => $userId,
             'status' => 'register-OVR',
         ], $this->faker->rockTheVoteStartedRegistration(1));
@@ -194,7 +194,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         // We shouldn't update the user's status to the row status, which has lower priority.
         $this->northstarMock->shouldNotReceive('updateUser');
         $this->rogueMock->shouldReceive('getPosts')->andReturn([
-            'data' => [0 => $existingCompletedPost],
+            'data' => [0 => $olderExistingCompletedPost],
         ]);
         // But we do create a new post, since we don't have one for this row's Started registration.
         $this->rogueMock->shouldReceive('createPost');

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -264,6 +264,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             ->with([
                 'northstar_id' => $user->id,
                 'action_id' => $record->postData['action_id'],
+                'type' => config('import.rock_the_vote.post.type'),
             ])
             ->andReturn(['data' => [0 => $post]]);
 
@@ -301,6 +302,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             ->with([
                 'northstar_id' => $user->id,
                 'action_id' => $record->postData['action_id'],
+                'type' => config('import.rock_the_vote.post.type'),
             ])
             ->andReturn(['data' => [0 => $firstPost, 1 => $secondPost]]);
 
@@ -328,6 +330,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             ->with([
                 'northstar_id' => $user->id,
                 'action_id' => $record->postData['action_id'],
+                'type' => config('import.rock_the_vote.post.type'),
             ])
             ->andReturn(['data' => null]);
 

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -133,10 +133,10 @@ class ImportRockTheVoteRecordTest extends TestCase
             'Status' => 'Complete',
             'Finish with State' => 'Yes',
         ]);
-        $existingPost  = $this->faker->rogueVoterRegPost([
+        $existingPost = $this->faker->rogueVoterRegPost([
             'id' => $postId,
             'northstar_id' => $userId,
-            'status' => 'step-1'
+            'status' => 'step-1',
         ], $startedRegistration);
         $importFile = factory(ImportFile::class)->create();
 
@@ -182,7 +182,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $existingPost = $this->faker->rogueVoterRegPost([
             'northstar_id' => $userId,
-            'status' => 'register-OVR'
+            'status' => 'register-OVR',
         ], $startedRegistration);
         $importFile = factory(ImportFile::class)->create();
 

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -83,7 +83,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     public function testDoesNotCreateOrUpdatePostIfCompletedPostFound()
     {
         $userId = $this->faker->northstar_id;
-        $startedRegistration = $this->faker->rockTheVoteStartedRegistration();
+        $startedRegistration = $this->faker->daysAgoInRockTheVoteFormat();
         $row = $this->faker->rockTheVoteReportRow([
             'Started registration' => $startedRegistration,
         ]);
@@ -126,7 +126,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     public function testUpdatesUserIfShouldChangeStatus()
     {
         $userId = $this->faker->northstar_id;
-        $startedRegistration = $this->faker->rockTheVoteStartedRegistration();
+        $startedRegistration = $this->faker->daysAgoInRockTheVoteFormat();
         $postId = $this->faker->randomDigitNotNull;
         $row = $this->faker->rockTheVoteReportRow([
             'Started registration' => $startedRegistration,
@@ -174,7 +174,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     public function testDoesNotUpdateUserIfShouldNotChangeStatus()
     {
         $userId = $this->faker->northstar_id;
-        $startedRegistration = $this->faker->rockTheVoteStartedRegistration();
+        $startedRegistration = $this->faker->daysAgoInRockTheVoteFormat();
         $row = $this->faker->rockTheVoteReportRow([
             'Started registration' => $startedRegistration,
             'Status' => 'Step 1',
@@ -183,7 +183,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $olderExistingCompletedPost = $this->faker->rogueVoterRegPost([
             'northstar_id' => $userId,
             'status' => 'register-OVR',
-        ], $this->faker->rockTheVoteStartedRegistration(1));
+        ], $this->faker->daysAgoInRockTheVoteFormat(1));
         $importFile = factory(ImportFile::class)->create();
 
         $this->mockGetNorthstarUser([
@@ -249,7 +249,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     public function testGetPostWhenPostWithSameStartedRegistrationIsFound()
     {
         $userId = $this->faker->northstar_id;
-        $startedRegistration = $this->faker->rockTheVoteStartedRegistration();
+        $startedRegistration = $this->faker->daysAgoInRockTheVoteFormat();
         $row = $this->faker->rockTheVoteReportRow([
             'Started registration' => $startedRegistration,
         ]);
@@ -283,7 +283,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     public function testGetPostWhenPostWithSameStartedRegistrationIsNotFound()
     {
         $userId = $this->faker->northstar_id;
-        $startedRegistration = $this->faker->rockTheVoteStartedRegistration();
+        $startedRegistration = $this->faker->daysAgoInRockTheVoteFormat();
         $row = $this->faker->rockTheVoteReportRow([
             'Started registration' => $startedRegistration,
         ]);
@@ -292,11 +292,11 @@ class ImportRockTheVoteRecordTest extends TestCase
         $firstPost = $this->faker->rogueVoterRegPost([
             'northstar_id' => $userId,
             'status' => 'register-OVR',
-        ], $this->faker->rockTheVoteStartedRegistration(2));
+        ], $this->faker->daysAgoInRockTheVoteFormat(2));
         $secondPost = $this->faker->rogueVoterRegPost([
             'northstar_id' => $userId,
             'status' => 'step-1',
-        ], $this->faker->rockTheVoteStartedRegistration(4));
+        ], $this->faker->daysAgoInRockTheVoteFormat(4));
 
         $this->rogueMock->shouldReceive('getPosts')
             ->with([

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -243,15 +243,14 @@ class ImportRockTheVoteRecordTest extends TestCase
      */
     public function testGetPostWhenPostIsFound()
     {
-        $row = $this->faker->rockTheVoteReportRow();
-        $record = new RockTheVoteRecord($row);
-        $user = new NorthstarUser([
-            'id' => $this->faker->northstar_id,
+        $userId = $this->faker->northstar_id;
+        $startedRegistration = '1/23/19 20:22';
+        $row = $this->faker->rockTheVoteReportRow([
+            'Started registration' => $startedRegistration,
         ]);
-        $post = [
-            'id' => $this->faker->randomDigitNotNull,
-            'status' => 'register-OVR',
-        ];
+        $record = new RockTheVoteRecord($row);
+        $user = new NorthstarUser(['id' => $userId]);
+        $post = $this->faker->rogueVoterRegPost($userId, $startedRegistration, 'register-OVR');
 
         $this->rogueMock->shouldReceive('getPosts')
             ->with([

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -33,6 +33,7 @@ trait WithMocks
         $this->faker = app(\Faker\Generator::class);
         $this->faker->addProvider(new \FakerNorthstarId($this->faker));
         $this->faker->addProvider(new \FakerRockTheVoteReportRow($this->faker));
+        $this->faker->addProvider(new \FakerRogueVoterRegPost($this->faker));
 
         // Northstar Mock
         $this->northstarMock = $this->mock(Northstar::class);


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the Rock the Vote `getPost` function to check for a matching "Started registration" value in the post details when returning a result. As a result (ha ha), we'll create a new `voter-reg` post every time a new "Started registration" is present for a user in a RTV report, instead of upserting a single post for all "Started registration" values.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This change corresponds to an org-wide change to base our topline metric of total voter registrations on gross registrations, where every completed voter registration application counts as a “voter registration” -- instead of unique users completing voter registration applications. See the [Voting Registration Problems/Solutions doc](https://docs.google.com/document/d/1An-JD0Tp6bQIvqYHfDpZvTjNwPkBxB8soB22ZLJ-lG8/edit#bookmark=id.lt5xqhgftxns) for more context.

### Relevant tickets

References [Pivotal #171737617](https://www.pivotaltracker.com/story/show/171737617)

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
