### PR TITLE
Starts on updating SMS information for existing users

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -262,7 +262,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
          * If we have a log for this registration that contains phone, we've already
          * updated user's subscription for this registration and should not proceed.
          */
-        if (RockTheVoteLog::hasSubmittedPhone($this->record, $user)) {
+        if (RockTheVoteLog::hasAlreadyUpdatedSmsSubscription($this->record, $user)) {
             return [];
         }
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -224,22 +224,22 @@ class ImportRockTheVoteRecord implements ShouldQueue
     }
 
     /**
-     * Get fields and values to update given user with.
+     * Update Northstar user with record data.
      *
-     * @return array
+     * @return void
      */
     public function updateUserIfChanged(NorthstarUser $user)
     {
         $payload = [];
 
         if (self::shouldUpdateStatus($user->voter_registration_status, $this->userData['voter_registration_status'])) {
-            $payload = array_only($this->userData, ['voter_registration_status']);
+            $payload['voter_registration_status'] = $this->userData['voter_registration_status'];
         }
 
         if (config('import.rock_the_vote.update_user_sms_enabled') == 'true') {
             $payload = array_merge($payload, $this->getUserSmsSubscriptionUpdatePayload($user));
         }
-        
+
         if (! count($payload)) {
             info('No changes to update for user', ['user' => $user->id]);
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -259,10 +259,13 @@ class ImportRockTheVoteRecord implements ShouldQueue
         }
 
         /**
-         * @TODO: If the RTV status is Complete: check whether we have a log for Step 3/Step 4.
-         * It would mean we've already processed this user's subscription preferences, and
-         * shouldn't update them again.
+         * If we have a log for this registration that contains phone, we've already
+         * updated user's subscription for this registration and should not proceed.
          */
+        if (RockTheVoteLog::hasSubmittedPhone($this->record, $user)) {
+            return [];
+        }
+
         $result = array_only($this->userData, ['sms_status', 'sms_subscription_topics']);
 
         // Save mobile if we don't have it currently stored on the user.

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -233,9 +233,9 @@ class ImportRockTheVoteRecord implements ShouldQueue
     /**
      * Get fields and values to update given user with.
      *
-     * @param NorthstarUser $user
+     * @return array
      */
-    private function getUpdateUserPayload($user)
+    public function getUpdateUserPayload(NorthstarUser $user)
     {
         $payload = [];
 
@@ -253,10 +253,9 @@ class ImportRockTheVoteRecord implements ShouldQueue
     /**
      * Get fields and values to update given user with if their SMS subscription has changed.
      *
-     * @param NorthstarUser $user
      * @return array
      */
-    public function getUpdateUserSmsSubscriptionPayload($user)
+    public function getUpdateUserSmsSubscriptionPayload(NorthstarUser $user)
     {
         $result = [];
 
@@ -265,10 +264,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
             return $result;
         }
 
-        /**
-         * If we have a log for this registration that contains phone, we've already updated the
-         * user's subscription for this registration, and should not proceed.
-         */
+        // We don't need to update user's SMS subscription if we already did for this registration.
         if (RockTheVoteLog::hasAlreadyUpdatedSmsSubscription($this->record, $user)) {
             return $result;
         }

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -247,7 +247,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
             return $payload;
         }
 
-        return array_merge($payload, $this->getUpdateUserSmsSubscriptionPayload($user));
+        return array_merge($payload, $this->getUserSmsSubscriptionUpdatePayload($user));
     }
 
     /**
@@ -255,7 +255,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
      *
      * @return array
      */
-    public function getUpdateUserSmsSubscriptionPayload(NorthstarUser $user)
+    public function getUserSmsSubscriptionUpdatePayload(NorthstarUser $user)
     {
         $result = [];
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -251,7 +251,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
      *
      * @return array
      */
-    private function getUpdateUserSmsSubscriptionPayload($user)
+    public function getUpdateUserSmsSubscriptionPayload($user)
     {
         // If we don't have a mobile, nothing to update.
         if (! $this->userData['mobile']) {

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -231,7 +231,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
     }
 
     /**
-     * Update Northstar user with record data.
+     * Get fields and values to update given user with.
      *
      * @param NorthstarUser $user
      */
@@ -251,8 +251,9 @@ class ImportRockTheVoteRecord implements ShouldQueue
     }
 
     /**
-     * Get fields and values to update if user SMS preferences have changed.
+     * Get fields and values to update given user with if their SMS subscription has changed.
      *
+     * @param NorthstarUser $user
      * @return array
      */
     public function getUpdateUserSmsSubscriptionPayload($user)
@@ -265,8 +266,8 @@ class ImportRockTheVoteRecord implements ShouldQueue
         }
 
         /**
-         * If we have a log for this registration that contains phone, we've already
-         * updated user's subscription for this registration and should not proceed.
+         * If we have a log for this registration that contains phone, we've already updated the
+         * user's subscription for this registration, and should not proceed.
          */
         if (RockTheVoteLog::hasAlreadyUpdatedSmsSubscription($this->record, $user)) {
             return $result;
@@ -274,7 +275,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
         // @TODO: Check for changes to user's SMS status and subscription topics.
 
-        // Save mobile if we don't have it currently stored on the user.
+        // Update user's mobile only if we currently don't have one saved.
         if (! $user->mobile) {
             $result['mobile'] = $this->userData['mobile'];
         }

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -76,10 +76,10 @@ class ImportRockTheVoteRecord implements ShouldQueue
             return;
         }
 
-        $updateUserPayload = $this->getUpdateUserPayload($user);
+        $userUpdatePayload = $this->getUserUpdatePayload($user);
 
-        if (count($updateUserPayload)) {
-            gateway('northstar')->asClient()->updateUser($user->id, $updateUserPayload);
+        if (count($userUpdatePayload)) {
+            gateway('northstar')->asClient()->updateUser($user->id, $userUpdatePayload);
             info('Updated user', ['user' => $user->id]);
         } else {
             info('No changes to update for user', ['user' => $user->id]);
@@ -235,7 +235,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
      *
      * @return array
      */
-    public function getUpdateUserPayload(NorthstarUser $user)
+    public function getUserUpdatePayload(NorthstarUser $user)
     {
         $payload = [];
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -243,6 +243,10 @@ class ImportRockTheVoteRecord implements ShouldQueue
             $payload = array_only($this->userData, ['voter_registration_status']);
         }
 
+        if (config('rock_the_vote.update_user_sms_enabled') === 'false') {
+            return $payload;
+        }
+
         return array_merge($payload, $this->getUpdateUserSmsSubscriptionPayload($user));
     }
 
@@ -253,9 +257,11 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function getUpdateUserSmsSubscriptionPayload($user)
     {
-        // If we don't have a mobile, nothing to update.
+        $result = [];
+
+        // If registration does not have a mobile provided, there is nothing to update.
         if (! $this->userData['mobile']) {
-            return [];
+            return $result;
         }
 
         /**
@@ -263,10 +269,10 @@ class ImportRockTheVoteRecord implements ShouldQueue
          * updated user's subscription for this registration and should not proceed.
          */
         if (RockTheVoteLog::hasAlreadyUpdatedSmsSubscription($this->record, $user)) {
-            return [];
+            return $result;
         }
 
-        $result = array_only($this->userData, ['sms_status', 'sms_subscription_topics']);
+        // @TODO: Check for changes to user's SMS status and subscription topics.
 
         // Save mobile if we don't have it currently stored on the user.
         if (! $user->mobile) {

--- a/app/Models/RockTheVoteLog.php
+++ b/app/Models/RockTheVoteLog.php
@@ -39,6 +39,8 @@ class RockTheVoteLog extends Model
 
     /**
      * Log sanitized Rock The Vote data for given user and import file.
+     *
+     * @return RockTheVoteLog
      */
     public static function createFromRecord(RockTheVoteRecord $record, NorthstarUser $user, ImportFile $importFile)
     {
@@ -62,6 +64,8 @@ class RockTheVoteLog extends Model
 
     /**
      * Find a log for given record and user.
+     * 
+     * @return RockTheVoteLog
      */
     public static function getByRecord(RockTheVoteRecord $record, NorthstarUser $user)
     {

--- a/app/Models/RockTheVoteLog.php
+++ b/app/Models/RockTheVoteLog.php
@@ -79,7 +79,7 @@ class RockTheVoteLog extends Model
     }
 
     /**
-     * Find whether a log exists for this registration containing user's phone number.
+     * Find whether a log exists for this registration and user that contains a phone number.
      *
      * @return bool
      */

--- a/app/Models/RockTheVoteLog.php
+++ b/app/Models/RockTheVoteLog.php
@@ -64,7 +64,7 @@ class RockTheVoteLog extends Model
 
     /**
      * Find a log for given record and user.
-     * 
+     *
      * @return RockTheVoteLog
      */
     public static function getByRecord(RockTheVoteRecord $record, NorthstarUser $user)
@@ -83,7 +83,7 @@ class RockTheVoteLog extends Model
      *
      * @return bool
      */
-    public static function hasSubmittedPhone(RockTheVoteRecord $record, NorthstarUser $user)
+    public static function hasAlreadyUpdatedSmsSubscription(RockTheVoteRecord $record, NorthstarUser $user)
     {
         $info = $record->getPostDetails();
 

--- a/app/Models/RockTheVoteLog.php
+++ b/app/Models/RockTheVoteLog.php
@@ -73,4 +73,22 @@ class RockTheVoteLog extends Model
             'user_id' => $user->id,
         ])->first();
     }
+
+    /**
+     * Find whether a log exists for this registration containing user's phone number.
+     *
+     * @return bool
+     */
+    public static function hasSubmittedPhone(RockTheVoteRecord $record, NorthstarUser $user)
+    {
+        $info = $record->getPostDetails();
+
+        $rockTheVoteLog = self::where([
+            'started_registration' => $info['Started registration'],
+            'user_id' => $user->id,
+            'contains_phone' => true,
+        ])->first();
+
+        return isset($rockTheVoteLog);
+    }
 }

--- a/config/import.php
+++ b/config/import.php
@@ -30,6 +30,7 @@ return [
         ],
     ],
     'rock_the_vote' => [
+        // Constants to use when creating a post.
         'post' => [
             'action_id' => env('ROCK_THE_VOTE_POST_ACTION_ID', 954),
             'type' => env('ROCK_THE_VOTE_POST_TYPE', 'voter-reg'),
@@ -44,6 +45,7 @@ return [
                 'Home zip code',
             ],
         ],
+        // Configuration for sending the Activate Account password reset email to new users.
         'reset' => [
             'enabled' => env('ROCK_THE_VOTE_RESET_ENABLED', 'true'),
             'type' => env('ROCK_THE_VOTE_RESET_TYPE', 'rock-the-vote-activate-account'),
@@ -68,6 +70,9 @@ return [
             'register-form',
             'registration_complete',
         ],
+        // Whether to update SMS profile information for an existing user.
+        'update_user_sms_enabled' => env('ROCK_THE_VOTE_UPDATE_USER_SMS_ENABLED', 'false'),
+        // Constants to use when creating a new user.
         'user' => [
             'email_subscription_topics' => env('ROCK_THE_VOTE_EMAIL_SUBSCRIPTION_TOPICS', 'community'),
             'sms_subscription_topics' => env('ROCK_THE_VOTE_SMS_SUBSCRIPTION_TOPICS', 'voting'),

--- a/database/faker/FakerRockTheVoteReportRow.php
+++ b/database/faker/FakerRockTheVoteReportRow.php
@@ -22,14 +22,14 @@ class FakerRockTheVoteReportRow extends Base
             'Email address' => $this->generator->email,
             'First name' => $this->generator->firstName,
             'Last name' => $this->generator->lastName,
-            'Phone' => $this->generator->phoneNumber,
+            'Phone' => null,
             'Finish with State' => 'Yes',
             'Pre-Registered' => 'No',
             'Started registration' => $this->daysAgoInRockTheVoteFormat(),
             'Status' => 'Step 1',
             'Tracking Source' => 'ads',
             'Opt-in to Partner email?' => 'Yes',
-            'Opt-in to Partner SMS/robocall' => 'Yes',
+            'Opt-in to Partner SMS/robocall' => 'No',
         ], $data);
     }
 

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -129,6 +129,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $startedRegistration = $this->faker->daysAgoInRockTheVoteFormat();
         $postId = $this->faker->randomDigitNotNull;
         $row = $this->faker->rockTheVoteReportRow([
+            'Phone' => $this->faker->phoneNumber,
             'Started registration' => $startedRegistration,
             'Status' => 'Complete',
             'Finish with State' => 'Yes',
@@ -150,6 +151,10 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $this->rogueMock->shouldNotReceive('createPost');
         $this->northstarMock->shouldReceive('updateUser')->with($userId, [
+            /**
+             * Note: If the ROCK_THE_VOTE_UPDATE_USER_SMS_ENABLED config var is set to true, we'd
+             * additionally update the user mobile field here too.
+             */
             'voter_registration_status' => 'registration_complete',
         ]);
         $this->rogueMock->shouldReceive('updatePost')->with($postId, [
@@ -381,8 +386,8 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $result = $job->getUpdateUserSmsSubscriptionPayload($user);;
-   
+        $result = $job->getUpdateUserSmsSubscriptionPayload($user);
+
         $this->assertEquals([], $result);
     }
 
@@ -403,8 +408,8 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $result = $job->getUpdateUserSmsSubscriptionPayload($user);;
-   
+        $result = $job->getUpdateUserSmsSubscriptionPayload($user);
+
         $this->assertEquals(['mobile' => $phoneNumber], $result);
     }
 
@@ -425,8 +430,8 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $result = $job->getUpdateUserSmsSubscriptionPayload($user);;
-   
+        $result = $job->getUpdateUserSmsSubscriptionPayload($user);
+
         $this->assertEquals([], $result);
     }
 

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -177,7 +177,7 @@ class ImportRockTheVoteRecordTest extends TestCase
      *
      * @return void
      */
-    public function testUserUpdatePayloadDoesNotContainsMobileIfUpdateUserSmsConfigIsDisabled()
+    public function testUserUpdatePayloadDoesNotContainMobileIfUpdateUserSmsConfigIsDisabled()
     {
         $user = new NorthstarUser([
             'id' => $this->faker->northstar_id,

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -132,7 +132,6 @@ class ImportRockTheVoteRecordTest extends TestCase
             'Started registration' => $startedRegistration,
             'Status' => 'Complete',
             'Finish with State' => 'Yes',
-            'Opt-in to Partner SMS/robocall' => 'No',
         ]);
         $existingInProgressPost = $this->faker->rogueVoterRegPost([
             'id' => $postId,
@@ -166,6 +165,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             'import_file_id' => $importFile->id,
         ]);
     }
+
 
     /**
      * Test that user is not updated if their voter registration status should not change.

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -132,6 +132,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             'Started registration' => $startedRegistration,
             'Status' => 'Complete',
             'Finish with State' => 'Yes',
+            'Opt-in to Partner SMS/robocall' => 'No',
         ]);
         $existingInProgressPost = $this->faker->rogueVoterRegPost([
             'id' => $postId,

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -177,7 +177,7 @@ class ImportRockTheVoteRecordTest extends TestCase
      *
      * @return void
      */
-    public function testUpdateUserPayloadContainsMobileIfUpdateUserSmsConfigIsEnabled()
+    public function testUserUpdatePayloadContainsMobileIfUpdateUserSmsConfigIsEnabled()
     {
         putenv('ROCK_THE_VOTE_UPDATE_USER_SMS_ENABLED=true');
 
@@ -193,7 +193,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $result = $job->getUpdateUserPayload($user);
+        $result = $job->getUserUpdatePayload($user);
 
         $this->assertEquals([
             'mobile' => $phoneNumber,

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -172,7 +172,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Test that user mobile is not updated when row has a phone, user does not have a mobile, and  * update_user_sms_enabled config is false. 
+     * Test that user mobile is not updated when row has a phone, user does not have a mobile, and
+     * update_user_sms_enabled config is false.
      *
      * @return void
      */
@@ -199,7 +200,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
     /**
      * Test that user mobile is updated when row has a phone, user does not have a mobile, and
-     * update_user_sms_enabled config is true. 
+     * update_user_sms_enabled config is true.
      *
      * @return void
      */

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -166,7 +166,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
     }
 
-
     /**
      * Test that user is not updated if their voter registration status should not change.
      *
@@ -347,7 +346,24 @@ class ImportRockTheVoteRecordTest extends TestCase
      *
      * @return void
      */
-    public function testUpdateUserSmsSubscriptionPayloadIsEmptyIfNoMobile()
+    public function testSmsSubscriptionPayloadIsEmptyIfMobileIsNull()
+    {
+        $row = $this->faker->rockTheVoteReportRow();
+        $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
+
+        $result = $job->getUpdateUserSmsSubscriptionPayload(new NorthstarUser([
+            'id' => $this->faker->northstar_id,
+        ]));
+
+        $this->assertEquals([], $result);
+    }
+
+    /**
+     * Test that update SMS payload is empty if a mobile is not provided.
+     *
+     * @return void
+     */
+    public function testSmsSubscriptionPayloadIsEmptyIfAlreadyUpdatedSmsSubscription()
     {
         $row = $this->faker->rockTheVoteReportRow();
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -342,6 +342,23 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->assertEquals($result, null);
     }
 
+    /*
+     * Test that update SMS payload is empty if a mobile is not provided.
+     *
+     * @return void
+     */
+    public function testUpdateUserSmsSubscriptionPayloadIsEmptyIfNoMobile()
+    {
+        $row = $this->faker->rockTheVoteReportRow();
+        $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
+
+        $result = $job->getUpdateUserSmsSubscriptionPayload(new NorthstarUser([
+            'id' => $this->faker->northstar_id,
+        ]));
+
+        $this->assertEquals([], $result);
+    }
+
     /**
      * Test that status should update when update value has higher priority than the current.
      *

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -388,7 +388,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $row = $this->faker->rockTheVoteReportRow();
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $result = $job->getUpdateUserSmsSubscriptionPayload(new NorthstarUser([
+        $result = $job->getUserSmsSubscriptionUpdatePayload(new NorthstarUser([
             'id' => $this->faker->northstar_id,
         ]));
 
@@ -418,7 +418,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $result = $job->getUpdateUserSmsSubscriptionPayload($user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($user);
 
         $this->assertEquals([], $result);
     }
@@ -440,7 +440,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $result = $job->getUpdateUserSmsSubscriptionPayload($user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($user);
 
         $this->assertEquals(['mobile' => $phoneNumber], $result);
     }
@@ -462,7 +462,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $result = $job->getUpdateUserSmsSubscriptionPayload($user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($user);
 
         $this->assertEquals([], $result);
     }

--- a/tests/Unit/Models/RockTheVoteLogTest.php
+++ b/tests/Unit/Models/RockTheVoteLogTest.php
@@ -98,11 +98,11 @@ class RockTheVoteLogTest extends TestCase
     }
 
     /**
-     * Test that getByRecord returns null when record and user not found.
+     * Test expected result when log exists for record and user that contains mobile.
      *
      * @return void
      */
-    public function testHasSubmittedPhoneWhenFound()
+    public function testHasAlreadyUpdatedSmsSubscription()
     {
         $user = new NorthstarUser(['id' => $this->faker->northstar_id]);
         $row = $this->faker->rockTheVoteReportRow();
@@ -113,7 +113,7 @@ class RockTheVoteLogTest extends TestCase
             'contains_phone' => true,
         ]);
 
-        $result = RockTheVoteLog::hasSubmittedPhone($record, $user);
+        $result = RockTheVoteLog::hasAlreadyUpdatedSmsSubscription($record, $user);
 
         $this->assertEquals($result, true);
     }

--- a/tests/Unit/Models/RockTheVoteLogTest.php
+++ b/tests/Unit/Models/RockTheVoteLogTest.php
@@ -25,7 +25,7 @@ class RockTheVoteLogTest extends TestCase
 
         $log = RockTheVoteLog::createFromRecord(new RockTheVoteRecord($row), $user, $importFile);
 
-        $this->assertEquals($log->contains_phone, true);
+        $this->assertEquals($log->contains_phone, isset($this->userData['mobile']));
         $this->assertEquals($log->finish_with_state, $row['Finish with State']);
         $this->assertEquals($log->import_file_id, $importFile->id);
         $this->assertEquals($log->pre_registered, $row['Pre-Registered']);
@@ -95,5 +95,26 @@ class RockTheVoteLogTest extends TestCase
         $result = RockTheVoteLog::getByRecord($record, $user);
 
         $this->assertEquals($result, null);
+    }
+
+    /**
+     * Test that getByRecord returns null when record and user not found.
+     *
+     * @return void
+     */
+    public function testHasSubmittedPhoneWhenFound()
+    {
+        $user = new NorthstarUser(['id' => $this->faker->northstar_id]);
+        $row = $this->faker->rockTheVoteReportRow();
+        $record = new RockTheVoteRecord($row);
+        $log = factory(RockTheVoteLog::class)->create([
+            'user_id' => $user->id,
+            'started_registration' => $row['Started registration'],
+            'contains_phone' => true,
+        ]);
+
+        $result = RockTheVoteLog::hasSubmittedPhone($record, $user);
+
+        $this->assertEquals($result, true);
     }
 }

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -15,7 +15,10 @@ class RockTheVoteRecordTest extends TestCase
      */
     public function testSetsUserDataAndPostData()
     {
-        $exampleRow = $this->faker->rockTheVoteReportRow();
+        $exampleRow = $this->faker->rockTheVoteReportRow([
+            'Phone' => $this->faker->phoneNumber,
+            'Opt-in to Partner SMS/robocall' => 'Yes',
+        ]);
         $config = ImportType::getConfig(ImportType::$rockTheVote);
 
         $record = new RockTheVoteRecord($exampleRow, $config);
@@ -59,6 +62,7 @@ class RockTheVoteRecordTest extends TestCase
     public function testDidNotOptIn()
     {
         $exampleRow = $this->faker->rockTheVoteReportRow([
+            'Phone' => $this->faker->phoneNumber,
             'Opt-in to Partner email?' => 'No',
             'Opt-in to Partner SMS/robocall' => 'No',
         ]);


### PR DESCRIPTION
### What's this PR do?

This pull request adds a feature flag to begin working on support for updating an existing user's SMS information, starting with the following changes:

* Adds a `RockTheVoteLog::hasAlreadyUpdatedSmsSubscription` function that checks to see whether a given registration record has already been imported with a phone number (refs #151)

* If `hasAlreadyUpdatedSmsSubscription` returns true, don't update the user's SMS information when importing the current registration record. We would have already updated the SMS information for the user in the previous registration record that contained a phone number, we don't want to opt them in again if they happened to unsubscribe since the last import ran that subscribed them.

* If `hasAlreadyUpdatedSmsSubscription` returns false, only write the user's `mobile` field when they don't have one set. Refs [Pivotal thread](https://www.pivotaltracker.com/story/show/171848124/comments/212652843).

### How should this be reviewed?

👀 

### Any background context you want to provide?

We won't want to enable this feature flag until:
1.  We add support for updating a user's SMS and status subscription topics based on whether the SMS opt-in is checked
2. Rock The Vote adds the SMS opt-in checkbox to their registration form

Will take on the work of the first item in another PR in hopes of keeping this one reviewable.

### Relevant tickets

References [Pivotal #171848124](https://www.pivotaltracker.com/story/show/171848124).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
