### PR TITLE
Finishes updating SMS information for existing users in RTV import

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -319,15 +319,13 @@ class ImportRockTheVoteRecord implements ShouldQueue
         }
 
         /**
-         * If user hasn't opted-in and has current subscription topics, remove if present.
-         *
-         * Note: we can get away with just checking for the config import topics because there we
-         * only have one.
+         * If user hasn't opted-in and has current subscription topics, remove any import topics
+         * from user's current subscription topics.
          */
         $result[$key] = [];
 
         foreach ($currentSmsTopics as $topic) {
-            if ($topic != config('import.rock_the_vote.user.sms_subscription_topics')) {
+            if (! in_array($topic, explode(',', config('import.rock_the_vote.user.sms_subscription_topics')))) {
                 array_push($result[$key], $topic);
             }
         }

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -260,19 +260,17 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function getUserSmsSubscriptionUpdatePayload(NorthstarUser $user)
     {
-        $payload = [];
-
         // If registration does not have a mobile provided, there is nothing to update.
         if (! $this->userData['mobile']) {
-            return $payload;
+            return [];
         }
 
         // We don't need to update user's SMS subscription if we already did for this registration.
         if (RockTheVoteLog::hasAlreadyUpdatedSmsSubscription($this->record, $user)) {
-            return $payload;
+            return [];
         }
 
-        $payload = array_merge($payload, $this->parseMobileChangeForUser($user));
+        $payload = $this->parseMobileChangeForUser($user);
         $payload = array_merge($payload, $this->parseSmsSubscriptionTopicsChangeForUser($user));
         $payload = array_merge($payload, $this->parseSmsStatusChangeForUser($user));
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -323,7 +323,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
          *
          * Note: we can get away with just checking for the first import topic since we only have one.
          */
-
         $importSmsTopicIndex = array_search(Arr::first($this->$importSmsTopics), $currentSmsTopics);
 
         if ($importSmsTopicIndex !== false) {
@@ -352,14 +351,14 @@ class ImportRockTheVoteRecord implements ShouldQueue
          *
          * This is an edge case for when we want to change an existing user's status to STOP.
          */
-        if ($currentSmsStatus == SmsStatus::$undeliverableStatus || ! $currentSmsStatus) {
+        if ($currentSmsStatus == SmsStatus::$undeliverable || ! $currentSmsStatus) {
             $result[$key] = $importSmsStatus;
 
             return $result;
         }
 
         // If user opted in via RTV form and is currently pending or opted out, opt them in.
-        if ($this->record->smsOptIn && in_array($currentSmsStatus, [SmsStatus::$pendingStatus, SmsStatus::$stopStatus])) {
+        if ($this->record->smsOptIn && in_array($currentSmsStatus, [SmsStatus::$pending, SmsStatus::$stop])) {
             $result[$key] = $importSmsStatus;
 
             return $result;

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -321,15 +321,16 @@ class ImportRockTheVoteRecord implements ShouldQueue
         /**
          * If user hasn't opted-in and has current subscription topics, remove if present.
          *
-         * Note: we can get away with just checking for the first import topic since we only have one.
+         * Note: we can get away with just checking for the config import topics because there we
+         * only have one.
          */
-        $importSmsTopicIndex = array_search(Arr::first($this->$importSmsTopics), $currentSmsTopics);
+        $result[$key] = [];
 
-        if ($importSmsTopicIndex !== false) {
-            unset($currentSmsTopics[$importSmsTopicIndex]);
+        foreach ($currentSmsTopics as $topic) {
+            if ($topic != config('import.rock_the_vote.user.sms_subscription_topics')) {
+                array_push($result[$key], $topic);
+            }
         }
-
-        $result[$key] = $currentSmsTopics;
 
         return $result;
     }

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -342,18 +342,20 @@ class ImportRockTheVoteRecord implements ShouldQueue
          * If current status is null or undeliverable, update status per whether they opted in
          * via the RTV form.
          *
-         * This is the only scenario when we want to change an existing user's status to STOP.
+         * This is the only scenario when we want to change an existing user's status to stop.
          */
         if ($currentSmsStatus == SmsStatus::$undeliverable || ! $currentSmsStatus) {
             return [$fieldName => $importSmsStatus];
         }
 
-        // If user opted in via RTV form and is currently pending or opted out, opt them in.
-        if ($this->smsOptIn && in_array($currentSmsStatus, [SmsStatus::$pending, SmsStatus::$stop])) {
+        if ($this->smsOptIn && in_array($currentSmsStatus, [
+            SmsStatus::$less,
+            SmsStatus::$pending,
+            SmsStatus::$stop,
+        ])) {
             return [$fieldName => $importSmsStatus];
         }
 
-        // If we've made it this far, nothing to update.
         return [];
     }
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -347,9 +347,10 @@ class ImportRockTheVoteRecord implements ShouldQueue
         $importSmsStatus = $this->userData[$key];
 
         /**
-         * If user is currently undeliverable, update status per whether they opted in via RTV form.
+         * If current status is null or undeliverable, update status per whether they opted in
+         * via the RTV form.
          *
-         * This is an edge case for when we want to change an existing user's status to STOP.
+         * This is the only scenario when we want to change an existing user's status to STOP.
          */
         if ($currentSmsStatus == SmsStatus::$undeliverable || ! $currentSmsStatus) {
             $result[$key] = $importSmsStatus;

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -38,6 +38,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
         $this->userData = $this->record->userData;
         $this->postData = $this->record->postData;
         $this->importFile = $importFile;
+        $this->smsOptIn = isset($this->userData['sms_status']) && $this->userData['sms_status'] == SmsStatus::$active;
     }
 
     /**
@@ -305,7 +306,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
         $currentSmsTopics = ! empty($user->{$fieldName}) ? $user->{$fieldName} : [];
 
         // If user opted in to SMS, add the import topics to current topics.
-        if ($this->record->smsOptIn) {
+        if ($this->smsOptIn) {
             return [$fieldName => array_unique(array_merge($currentSmsTopics, $this->userData[$fieldName]))];
         }
 
@@ -348,7 +349,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
         }
 
         // If user opted in via RTV form and is currently pending or opted out, opt them in.
-        if ($this->record->smsOptIn && in_array($currentSmsStatus, [SmsStatus::$pending, SmsStatus::$stop])) {
+        if ($this->smsOptIn && in_array($currentSmsStatus, [SmsStatus::$pending, SmsStatus::$stop])) {
             return [$fieldName => $importSmsStatus];
         }
 

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -53,7 +53,7 @@ class RockTheVoteRecord
 
         if ($this->userData['mobile']) {
             $smsOptIn = str_to_boolean($record[static::$smsOptInFieldName]);
-    
+
             $this->userData['sms_status'] = $smsOptIn ? SmsStatus::$active : SmsStatus::$stop;
             $this->userData['sms_subscription_topics'] = $smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
         }

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -7,6 +7,18 @@ use Illuminate\Support\Str;
 class RockTheVoteRecord
 {
     /**
+     * @var string
+     */
+    public static $mobileFieldName = 'Phone';
+
+    /**
+     * Note: Note: Not a typo, this column name does not have the trailing question mark.
+     *
+     * @var string
+     */
+    public static $smsOptInFieldName = 'Opt-in to Partner SMS/robocall';
+
+    /**
      * Parses values to send to DS API from given CSV record, using given config.
      *
      * @param array $record
@@ -20,8 +32,7 @@ class RockTheVoteRecord
 
         $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);
 
-        // Note: Not a typo, this column name does not have the trailing question mark.
-        $this->smsOptIn = str_to_boolean($record['Opt-in to Partner SMS/robocall']);
+        $this->smsOptIn = str_to_boolean($record[static::$smsOptInFieldName]);
 
         $rtvStatus = $this->parseVoterRegistrationStatus($record['Status'], $record['Finish with State']);
 
@@ -33,7 +44,7 @@ class RockTheVoteRecord
             'email' => $record['Email address'],
             'first_name' => $record['First name'],
             'last_name' => $record['Last name'],
-            'mobile' => isset($record['Phone']) && is_valid_mobile($record['Phone']) ? $record['Phone'] : null,
+            'mobile' => isset($record[static::$mobileFieldName]) && is_valid_mobile($record[static::$mobileFieldName]) ? $record[static::$mobileFieldName] : null,
             'email_subscription_status' => $emailOptIn,
             'email_subscription_topics' => $emailOptIn ? explode(',', $config['user']['email_subscription_topics']) : [],
             'voter_registration_status' => Str::contains($rtvStatus, 'register') ? 'registration_complete' : $rtvStatus,
@@ -43,7 +54,7 @@ class RockTheVoteRecord
         ];
 
         if ($this->userData['mobile']) {
-            $this->userData['sms_status'] = $this->smsOptIn ? SmsStatus::$activeStatus : SmsStatus::$stopStatus;
+            $this->userData['sms_status'] = $this->smsOptIn ? SmsStatus::$active : SmsStatus::$stop;
             $this->userData['sms_subscription_topics'] = $this->smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
         }
 

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -31,7 +31,6 @@ class RockTheVoteRecord
         }
 
         $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);
-
         $rtvStatus = $this->parseVoterRegistrationStatus($record['Status'], $record['Finish with State']);
 
         $this->userData = [

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -32,8 +32,6 @@ class RockTheVoteRecord
 
         $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);
 
-        $this->smsOptIn = str_to_boolean($record[static::$smsOptInFieldName]);
-
         $rtvStatus = $this->parseVoterRegistrationStatus($record['Status'], $record['Finish with State']);
 
         $this->userData = [
@@ -54,8 +52,10 @@ class RockTheVoteRecord
         ];
 
         if ($this->userData['mobile']) {
-            $this->userData['sms_status'] = $this->smsOptIn ? SmsStatus::$active : SmsStatus::$stop;
-            $this->userData['sms_subscription_topics'] = $this->smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
+            $smsOptIn = str_to_boolean($record[static::$smsOptInFieldName]);
+    
+            $this->userData['sms_status'] = $smsOptIn ? SmsStatus::$active : SmsStatus::$stop;
+            $this->userData['sms_subscription_topics'] = $smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
         }
 
         $this->postData = [

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -12,7 +12,7 @@ class RockTheVoteRecord
     public static $mobileFieldName = 'Phone';
 
     /**
-     * Note: Note: Not a typo, this column name does not have the trailing question mark.
+     * Note: Not a typo, this column name does not have the trailing question mark.
      *
      * @var string
      */

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -19,6 +19,10 @@ class RockTheVoteRecord
         }
 
         $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);
+
+        // Note: Not a typo, this column name does not have the trailing question mark.
+        $this->smsOptIn = str_to_boolean($record['Opt-in to Partner SMS/robocall']);
+
         $rtvStatus = $this->parseVoterRegistrationStatus($record['Status'], $record['Finish with State']);
 
         $this->userData = [
@@ -39,11 +43,8 @@ class RockTheVoteRecord
         ];
 
         if ($this->userData['mobile']) {
-            // Note: Not a typo, this column name does not have the trailing question mark.
-            $smsOptIn = str_to_boolean($record['Opt-in to Partner SMS/robocall']);
-
-            $this->userData['sms_status'] = $smsOptIn ? 'active' : 'stop';
-            $this->userData['sms_subscription_topics'] = $smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
+            $this->userData['sms_status'] = $this->smsOptIn ? SmsStatus::$activeStatus : SmsStatus::$stopStatus;
+            $this->userData['sms_subscription_topics'] = $this->smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
         }
 
         $this->postData = [

--- a/app/SmsStatus.php
+++ b/app/SmsStatus.php
@@ -7,25 +7,25 @@ class SmsStatus
     /**
      * @var string
      */
-    public static $activeStatus = 'active';
+    public static $active = 'active';
 
     /**
      * @var string
      */
-    public static $lessStatus = 'less';
+    public static $less = 'less';
 
     /**
      * @var string
      */
-    public static $pendingStatus = 'pending';
+    public static $pending = 'pending';
 
     /**
      * @var string
      */
-    public static $stopStatus = 'stop';
+    public static $stop = 'stop';
 
     /**
      * @var string
      */
-    public static $undeliverableStatus = 'undeliverable';
+    public static $undeliverable = 'undeliverable';
 }

--- a/app/SmsStatus.php
+++ b/app/SmsStatus.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Chompy;
+
+class SmsStatus
+{
+    /**
+     * @var string
+     */
+    public static $activeStatus = 'active';
+
+    /**
+     * @var string
+     */
+    public static $lessStatus = 'less';
+
+    /**
+     * @var string
+     */
+    public static $pendingStatus = 'pending';
+
+    /**
+     * @var string
+     */
+    public static $stopStatus = 'stop';
+
+    /**
+     * @var string
+     */
+    public static $undeliverableStatus = 'undeliverable';
+}

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -8,7 +8,7 @@ The import upserts a `voter-reg` type post for each unique "Started registration
 
 If a user registers to vote twice in 2020 (e.g. change of address), two `voter-reg` posts will be upserted for the user and this year's action. Prior to [changes made in April 2020](https://github.com/DoSomething/chompy/pull/154), the import would upsert a single post for all registrations for an action ID (e.g registering to vote twice in 2018 resulted in a single `voter-reg` post).
 
-## Voter Registration Status
+## Status
 
 As of [April 2020](https://github.com/DoSomething/chompy/pull/153), we save the status provided by Rock The Vote on `voter-reg` posts for Rock the Vote, with the exception of using two different statuses for the `Complete` status:
 
@@ -67,9 +67,11 @@ We’ve established this hierarchy because each time a user interacts with the R
 
 In this case, we would want to count the form completion (`register-form`). It’s important to note that the hierarchy is for internal reporting and doesn’t prevent the user from interacting with the RTV form if they want to do so.
 
-### Existing Users
+## Existing Users
 
-If an existing User is found using the NS ID, email, or number, we attempt to update the user's `voter_registration_status` profile field based on the new status from the record.
+If an existing User is found using the NS ID, email, or number, we may update the user's `voter_registration_status` or SMS preferences based on the new values from the record.
+
+### Voter Registration Status
 
 If there's an existing status on the user, we follow the same hierarchy rules established above but check for a few additional statuses:
 
@@ -91,7 +93,28 @@ So the full hierarchy order taken into account when updating the profile from lo
 - `confirmed`
 - `registration_complete`
 
-### New Users
+### Mobile
+
+If an existing user has a null `mobile` profile field and provides a phone number via RTV form, we save it to the user's `mobile` profile field.
+
+**Notes**:
+
+- We do **not** override an existing phone number.
+- We save a user's mobile number regardless of whether they opt-in to SMS messaging from DS.
+
+### SMS Status
+
+If an existing user **opts-in** to voting-related SMS messaging from DS via RTV form, we update `sms_status` as `active` if current value is either null, `less`, `stop`, or `undeliverable`.
+
+If an existing user **opts-out** of voting-related SMS messaging from DS via RTV form, we udate `sms_status` as `stop` if current value is null or `undeliverable`.
+
+### SMS Subscription Topics
+
+If an existing user **opts-in** to voting-related SMS messaging from DS via RTV form, we add the `voting` topic to their `sms_subscription_topics` if it doesn't exist.
+
+If an existing user **opts-out** of voting-related SMS messaging from DS via RTV form, we remove the `voting` topic from their `sms_subscription_topics` if it exists.
+
+## New Users
 
 If the referral column doesn't have a NS ID, we try to find to a user by email, and last by mobile number. If a user is still not found, then create a NS account for them with the PII provided from Rock The Vote.
 

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -106,7 +106,7 @@ If an existing user has a null `mobile` profile field and provides a phone numbe
 
 If an existing user **opts-in** to voting-related SMS messaging from DS via RTV form, we update `sms_status` as `active` if current value is either null, `less`, `stop`, or `undeliverable`.
 
-If an existing user **opts-out** of voting-related SMS messaging from DS via RTV form, we udate `sms_status` as `stop` if current value is null or `undeliverable`.
+If an existing user **opts-out** of voting-related SMS messaging from DS via RTV form, we update `sms_status` as `stop` if current value is null or `undeliverable`.
 
 ### SMS Subscription Topics
 

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -10,6 +10,7 @@ use Chompy\Models\RockTheVoteLog;
 use Chompy\Jobs\ImportRockTheVoteRecord;
 use DoSomething\Gateway\Resources\NorthstarUser;
 
+// @TODO: Replace all hardcoded RTV field names with RockTheVoteRecord constants to DRY.
 class ImportRockTheVoteRecordTest extends TestCase
 {
     /**

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -620,7 +620,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Tests SMS status is updated to active if user with undeliverable value opts-in to RTV SMS.
+     * Tests SMS status is updated to stop if user with undeliverable value opts-in to RTV SMS.
      *
      * @return void
      */
@@ -630,6 +630,29 @@ class ImportRockTheVoteRecordTest extends TestCase
             'id' => $this->faker->northstar_id,
             'mobile' => $this->faker->phoneNumber,
             'sms_status' => SmsStatus::$undeliverable,
+        ]);
+        $row = $this->faker->rockTheVoteReportRow([
+            RockTheVoteRecord::$mobileFieldName => $this->faker->phoneNumber,
+            RockTheVoteRecord::$smsOptInFieldName => 'No',
+        ]);
+        $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
+
+        $result = $job->parseSmsStatusChangeForUser($user);
+
+        $this->assertEquals(['sms_status' => SmsStatus::$stop], $result);
+    }
+
+    /**
+     * Tests SMS status is updated to stop if user with null value opts-out of RTV SMS.
+     *
+     * @return void
+     */
+    public function testParseSmsStatusChangeIfUserHasNullSmsStatusAndOptsOut()
+    {
+        $user = new NorthstarUser([
+            'id' => $this->faker->northstar_id,
+            'mobile' => $this->faker->phoneNumber,
+            'sms_status' => null,
         ]);
         $row = $this->faker->rockTheVoteReportRow([
             RockTheVoteRecord::$mobileFieldName => $this->faker->phoneNumber,

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -10,7 +10,6 @@ use Chompy\Models\RockTheVoteLog;
 use Chompy\Jobs\ImportRockTheVoteRecord;
 use DoSomething\Gateway\Resources\NorthstarUser;
 
-// @TODO: Replace all hardcoded RTV field names with RockTheVoteRecord constants to DRY.
 class ImportRockTheVoteRecordTest extends TestCase
 {
     /**
@@ -718,7 +717,7 @@ class ImportRockTheVoteRecordTest extends TestCase
      *
      * @return void
      */
-    public function testParseSubscriptionTopicsChangeIfUserOptsIn()
+    public function testParseSubscriptionTopicsChangeIfUserOptsOut()
     {
         $user = new NorthstarUser([
             'id' => $this->faker->northstar_id,
@@ -766,7 +765,7 @@ class ImportRockTheVoteRecordTest extends TestCase
      *
      * @return void
      */
-    public function testParseSubscriptionTopicsChangeIfUserHasTopicsAndOptsOut()
+    public function testParseSubscriptionTopicsChangeIfUserHasTopicsAndOptsIn()
     {
         $user = new NorthstarUser([
             'id' => $this->faker->northstar_id,

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Jobs\RockTheVote;
 
 use Tests\TestCase;
+use Chompy\SmsStatus;
 use Chompy\RockTheVoteRecord;
 use Chompy\Models\ImportFile;
 use Chompy\Models\RockTheVoteLog;
@@ -222,6 +223,8 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $this->northstarMock->shouldReceive('updateUser')->with($user->id, [
             'mobile' => $phoneNumber,
+            'sms_status' => SmsStatus::$activeStatus,
+            'sms_subscription_topics' => ['voting'],
             'voter_registration_status' => 'step-2',
         ]);
 
@@ -469,7 +472,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $result = $job->getUserSmsSubscriptionUpdatePayload($user);
 
-        $this->assertEquals(['mobile' => $phoneNumber], $result);
+        $this->assertEquals(['mobile' => $phoneNumber, 'sms_status' => SmsStatus::$stopStatus], $result);
     }
 
     /**
@@ -483,6 +486,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $user = new NorthstarUser([
             'id' => $this->faker->northstar_id,
             'mobile' => $this->faker->phoneNumber,
+            'sms_status' => SmsStatus::$lessStatus,
         ]);
         $row = $this->faker->rockTheVoteReportRow([
             'Phone' => $this->faker->phoneNumber,

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -522,6 +522,52 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
+     * Test that SMS status is updated to active if user with stop value opts-in to SMS.
+     *
+     * @return void
+     */
+    public function testParseSmsStatusChangeIfUserHasStopmsStatusAndOptsIn()
+    {
+        $user = new NorthstarUser([
+            'id' => $this->faker->northstar_id,
+            'mobile' => $this->faker->phoneNumber,
+            'sms_status' => SmsStatus::$stop,
+        ]);
+        $row = $this->faker->rockTheVoteReportRow([
+            RockTheVoteRecord::$mobileFieldName => $this->faker->phoneNumber,
+            RockTheVoteRecord::$smsOptInFieldName => 'Yes',
+        ]);
+        $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
+
+        $result = $job->parseSmsStatusChangeForUser($user);
+
+        $this->assertEquals(['sms_status' => SmsStatus::$active], $result);
+    }
+
+    /**
+     * Tests SMS status is updated to active if user with null value opts-in to RTV SMS.
+     *
+     * @return void
+     */
+    public function testParseSmsStatusChangeIfUserHasNullSmsStatusAndOptsIn()
+    {
+        $user = new NorthstarUser([
+            'id' => $this->faker->northstar_id,
+            'mobile' => $this->faker->phoneNumber,
+            'sms_status' => null,
+        ]);
+        $row = $this->faker->rockTheVoteReportRow([
+            RockTheVoteRecord::$mobileFieldName => $this->faker->phoneNumber,
+            RockTheVoteRecord::$smsOptInFieldName => 'Yes',
+        ]);
+        $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
+
+        $result = $job->parseSmsStatusChangeForUser($user);
+
+        $this->assertEquals(['sms_status' => SmsStatus::$active], $result);
+    }
+
+    /**
      * Tests SMS status is updated to active if user with undeliverable value opts-in to RTV SMS.
      *
      * @return void

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -528,6 +528,29 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
+     * Test that SMS status is updated to active if user with less value opts-in to SMS.
+     *
+     * @return void
+     */
+    public function testParseSmsStatusChangeIfUserHasLessSmsStatusAndOptsIn()
+    {
+        $user = new NorthstarUser([
+            'id' => $this->faker->northstar_id,
+            'mobile' => $this->faker->phoneNumber,
+            'sms_status' => SmsStatus::$less,
+        ]);
+        $row = $this->faker->rockTheVoteReportRow([
+            RockTheVoteRecord::$mobileFieldName => $this->faker->phoneNumber,
+            RockTheVoteRecord::$smsOptInFieldName => 'Yes',
+        ]);
+        $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
+
+        $result = $job->parseSmsStatusChangeForUser($user);
+
+        $this->assertEquals(['sms_status' => SmsStatus::$active], $result);
+    }
+
+    /**
      * Test that SMS status is updated to active if user with stop value opts-in to SMS.
      *
      * @return void

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -503,7 +503,7 @@ class ImportRockTheVoteRecordTest extends TestCase
      *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasPendingSmsStatus()
+    public function testParseSmsStatusChangeIfUserHasPendingSmsStatusAndOptsIn()
     {
         $user = new NorthstarUser([
             'id' => $this->faker->northstar_id,
@@ -522,11 +522,11 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Test that SMS status is updated to active if user with undeliverable value opts-in to SMS.
+     * Tests SMS status is updated to active if user with undeliverable value opts-in to RTV SMS.
      *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasUndeliverableSmsStatus()
+    public function testParseSmsStatusChangeIfUserHasUndeliverableSmsStatusAndOptsIn()
     {
         $user = new NorthstarUser([
             'id' => $this->faker->northstar_id,
@@ -542,6 +542,52 @@ class ImportRockTheVoteRecordTest extends TestCase
         $result = $job->parseSmsStatusChangeForUser($user);
 
         $this->assertEquals(['sms_status' => SmsStatus::$active], $result);
+    }
+
+    /**
+     * Tests SMS status is updated to active if user with undeliverable value opts-in to RTV SMS.
+     *
+     * @return void
+     */
+    public function testParseSmsStatusChangeIfUserHasUndeliverableSmsStatusAndOptsOut()
+    {
+        $user = new NorthstarUser([
+            'id' => $this->faker->northstar_id,
+            'mobile' => $this->faker->phoneNumber,
+            'sms_status' => SmsStatus::$undeliverable,
+        ]);
+        $row = $this->faker->rockTheVoteReportRow([
+            RockTheVoteRecord::$mobileFieldName => $this->faker->phoneNumber,
+            RockTheVoteRecord::$smsOptInFieldName => 'No',
+        ]);
+        $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
+
+        $result = $job->parseSmsStatusChangeForUser($user);
+
+        $this->assertEquals(['sms_status' => SmsStatus::$stop], $result);
+    }
+
+    /**
+     * Tests SMS status is not updated if user with active value opts-out of RTV SMS.
+     *
+     * @return void
+     */
+    public function testParseSmsStatusChangeIfUserHasActiveSmsStatusAndOptsOut()
+    {
+        $user = new NorthstarUser([
+            'id' => $this->faker->northstar_id,
+            'mobile' => $this->faker->phoneNumber,
+            'sms_status' => SmsStatus::$active,
+        ]);
+        $row = $this->faker->rockTheVoteReportRow([
+            RockTheVoteRecord::$mobileFieldName => $this->faker->phoneNumber,
+            RockTheVoteRecord::$smsOptInFieldName => 'No',
+        ]);
+        $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
+
+        $result = $job->parseSmsStatusChangeForUser($user);
+
+        $this->assertEquals([], $result);
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the Rock The Vote import to update an existing user's `sms_status` and `sms_subscription_topics` based on whether they opt-in to receive voting related texts from DS when they register to vote (Note: this opt-in isn't visible on the RTV site yet, which is why these changes that were started in #155 are still feature flagged)

The expected behavior for changes to the  `sms_status` and `sms_subscription_topics` have been [added to the documentation in this PR](https://github.com/DoSomething/chompy/blob/rtv-sms-status/docs/imports/rock-the-vote.md#sms-status), copy/pasting here:

**SMS Status**

* If an existing user opts-in to voting-related SMS messaging from DS via RTV form, we update sms_status as active if current value is either null, less, stop, or undeliverable.

* If an existing user opts-out of voting-related SMS messaging from DS via RTV form, we update sms_status as stop if current value is null or undeliverable.

**SMS Subscription Topics**

* If an existing user opts-in to voting-related SMS messaging from DS via RTV form, we add the voting topic to their sms_subscription_topics if it doesn't exist.

* If an existing user opts-out of voting-related SMS messaging from DS via RTV form, we remove the voting topic from their sms_subscription_topics if it exists

### How should this be reviewed?

The bulk of this PR are unit tests to make sure the update values are expected per a user's current `sms_status` and `sms_subscription_topics` fields. It's a little tedious to test each SMS status value and opting in and out, but also felt like the 100% way to feel all bases were covered. Trying to put together a test CSV to manually spot check this against your local Northstar users db collection feels way more painful and error-prone.

### Any background context you want to provide?

Besides needing the RTV checkbox visible before we enable the feature flag, we also want to backfill the `sms_subscription_topics` of all existing SMS subscribers with  `general` and `voting` -- so we can honor an existing user's preference to opt-out ONLY of voting texts, and not all general texts from DS.

### Relevant tickets

References [Pivotal #171848124](https://www.pivotaltracker.com/story/show/171848124), [Slack thread](https://dosomething.slack.com/archives/C03T8SDMS/p1586798992063300).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
