### PR TITLE
RTV import cleanup

### DIFF
--- a/app/Http/Controllers/Web/ImportFileController.php
+++ b/app/Http/Controllers/Web/ImportFileController.php
@@ -150,7 +150,7 @@ class ImportFileController extends Controller
         if ($importType === ImportType::$rockTheVote) {
             $row = [
                 'Email address' => $request->input('email'),
-                'Finish with State' => $request->input('finish_with_state'),
+                'Finish with State' => $request->input('finish_with_state') ?: 'No',
                 'First name' => $request->input('first_name'),
                 'Home address' => $request->input('addr_street1'),
                 'Home city' => $request->input('addr_city'),

--- a/app/Http/Controllers/Web/ImportFileController.php
+++ b/app/Http/Controllers/Web/ImportFileController.php
@@ -56,8 +56,8 @@ class ImportFileController extends Controller
                 'email' => $user->email,
                 'first_name' => $user->first_name,
                 'last_name' => $user->last_name,
-                'mobile' => $user->mobile,
-                'referral' => 'ads',
+                'phone' => $user->mobile,
+                'tracking_source' => 'source:test,source_details:ChompyUI',
                 'started_registration' => Carbon::now()->format('Y-m-d H:i:s O'),
             ];
         }
@@ -150,7 +150,7 @@ class ImportFileController extends Controller
         if ($importType === ImportType::$rockTheVote) {
             $row = [
                 'Email address' => $request->input('email'),
-                'Finish with State' => $request->input('status'),
+                'Finish with State' => $request->input('finish_with_state'),
                 'First name' => $request->input('first_name'),
                 'Home address' => $request->input('addr_street1'),
                 'Home city' => $request->input('addr_city'),
@@ -159,11 +159,11 @@ class ImportFileController extends Controller
                 'Last name' => $request->input('last_name'),
                 'Opt-in to Partner SMS/robocall' => $request->input('sms_opt_in') ?: 'No',
                 'Opt-in to Partner email?' => $request->input('email_opt_in') ?: 'No',
-                'Phone' => $request->input('mobile'),
+                'Phone' => $request->input('phone'),
                 'Pre-Registered' => $request->input('pre_registered') ?: 'No',
                 'Started registration' => $request->input('started_registration'),
                 'Status' => $request->input('status'),
-                'Tracking Source' => $request->input('referral'),
+                'Tracking Source' => $request->input('tracking_source'),
             ];
 
             $importFile = new ImportFile();

--- a/app/Http/Controllers/Web/ImportFileController.php
+++ b/app/Http/Controllers/Web/ImportFileController.php
@@ -57,7 +57,7 @@ class ImportFileController extends Controller
                 'first_name' => $user->first_name,
                 'last_name' => $user->last_name,
                 'mobile' => $user->mobile,
-                'referral' => 'user:'.$userId.',source:test,source_detail:ChompyUI',
+                'referral' => 'ads',
                 'started_registration' => Carbon::now()->format('Y-m-d H:i:s O'),
             ];
         }

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -291,8 +291,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
         $fieldName = 'mobile';
 
         if ($user->{$fieldName}) {
-            info('User already has mobile');
-
             return [];
         }
 
@@ -309,7 +307,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
         $fieldName = 'sms_subscription_topics';
         $currentSmsTopics = ! empty($user->{$fieldName}) ? $user->{$fieldName} : [];
 
-
         // If user opted in to SMS, add the import topics to current topics.
         if ($this->smsOptIn) {
             return [$fieldName => array_unique(array_merge($currentSmsTopics, $this->userData[$fieldName]))];
@@ -317,8 +314,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
         // Nothing to remove if current topics in empty.
         if (! count($currentSmsTopics)) {
-            info('User does not have any SMS subscription topics to remove', ['user' => $user->id]);
-
             return [];
         }
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -309,9 +309,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
         $fieldName = 'sms_subscription_topics';
         $currentSmsTopics = ! empty($user->{$fieldName}) ? $user->{$fieldName} : [];
 
-        // @TODO: Remove this and fix a big bug, our $user does not have a sms_subscription_topics
-        // property set here -- so we are not property updating this field.
-        info('User ' . print_r($user, true));
 
         // If user opted in to SMS, add the import topics to current topics.
         if ($this->smsOptIn) {

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -123,6 +123,7 @@ If the referral column doesn't have a NS ID, we try to find to a user by email, 
 - First Name
 - Last Name
 - Street Address, City, Zip
+- Email
 - Mobile
 
 Note: We do not import the user's birthdate, likely for [privacy concerns](https://dosomething.slack.com/archives/CTVPG6L4R/p1587153485493600?thread_ts=1587153236.493300&cid=CTVPG6L4R).

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -132,7 +132,7 @@ If the referral column doesn't have a NS ID, we try to find to a user by email, 
 
   - If user opts-out of SMS messging from DS, user's `voting` SMS topic is removed if exists. SMS status will be set to `active` if was previously set to `stop` or `undeliverable`.
 
-- [Voter Registration Status](/#voter-registration-status)
+- Voter Registration Status
 
 ### Online Drives
 

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -136,7 +136,7 @@ If the referral column doesn't have a NS ID, we try to find to a user by email, 
 
   - If user opts-in to SMS messging from DS, user is subscribed to the `voting` SMS topic with status `active`.
 
-  - If user opts-out of SMS messging from DS, user's `voting` SMS topic is removed if exists. SMS status will be set to `active` if was previously set to `stop` or `undeliverable`.
+  - If user opts-out of SMS messging from DS, user's `sms_status` will be set to `stop` and `sms_subscription_topics` will be set to empty.
 
 - Voter Registration Status
 

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -24,7 +24,7 @@ The other status values returned from RTV are:
 
 - `step-1`: a person entered email/ZIP code on the first page, then stopped.
 
-  - Note -- we've seen PII entered in rows that are on Step 1, and TBD why this happens sometimes.
+  - Note -- we've seen profile info entered in rows that are on Step 1, and TBD why this happens sometimes.
 
 - `step-2`: user got to the second page to start filling out their personal info, but did not finish
 
@@ -71,8 +71,6 @@ In this case, we would want to count the form completion (`register-form`). Itâ€
 
 If an existing User is found using the NS ID, email, or number, we may update the user's `voter_registration_status` or SMS preferences based on the new values from the record.
 
-Note: We do not update any PII for an existing user (except for a mobile, if we do not have one saved already).
-
 ### Voter Registration Status
 
 If there's an existing status on the user, we follow the same hierarchy rules established above but check for a few additional statuses:
@@ -118,15 +116,21 @@ If an existing user **opts-out** of voting-related SMS messaging from DS via RTV
 
 ## New Users
 
-If the referral column doesn't have a NS ID, we try to find to a user by email, and last by mobile number. If a user is still not found, then create a NS account for them with PII provided from Rock The Vote:
+If the referral column doesn't have a NS ID, we try to find to a user by email, and last by mobile number. If a user is still not found, then create a NS account for them with the following info provided from Rock The Vote:
 
-- First Name
-- Last Name
-- Street Address, City, Zip
+- First and last name
+
+- Address, City, Zip
+
 - Email
+
+  - If user opts-in to email messaging from DS, user is subscribed with `community` topic and an Activate Account email is sent.
+
 - Mobile
 
-Note: We do not import the user's birthdate, likely for [privacy concerns](https://dosomething.slack.com/archives/CTVPG6L4R/p1587153485493600?thread_ts=1587153236.493300&cid=CTVPG6L4R).
+  - If user opts-in to SMS messging from DS, user is subscribed to the `voting` SMS topic with status `active`.
+
+  - If user opts-out of SMS messging from DS, user's `voting` SMS topic is removed if exists. SMS status will be set to `active` if was previously set to `stop` or `undeliverable`.
 
 ### Online Drives
 

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -144,7 +144,7 @@ If the referral column doesn't have a NS ID, we try to find to a user by email, 
 
 Online drives is one of the tactics we have for getting people to get their friends registered to vote. For example, someone would sign up for the campaign and they have their own personal registration page (w/ a RTV form on it w/ the same kind of tracking) that they share with their friends/family. The appeal for them is that on their campaign action page, it will show how many people has viewed their personal registration page (v2 feature enhancement might be upping this to show who has registered).
 
-So, the Alpha sends their page to a Beta and they register. The Alpha's referral links look like this: https://vote.dosomething.org/member-drive?userId={userId}&r=user:{userId},source=web,source_details=onlinedrivereferral,referral=true
+So, the Alpha sends their page to a Beta and they register. The Alpha's referral links look like this: https://vote.dosomething.org/member-drive?userId=58e68d5da0bfad4c3b4cd722&r=user:58e68d5da0bfad4c3b4cd722,source=web,source_details=onlinedrivereferral,referral=true
 
 We've added `referral=true` to the link so that we can know to not attribute the registration to the NS ID that is present in the URL. In this case, this NS ID is the referrer and not the registrant.
 

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -132,6 +132,8 @@ If the referral column doesn't have a NS ID, we try to find to a user by email, 
 
   - If user opts-out of SMS messging from DS, user's `voting` SMS topic is removed if exists. SMS status will be set to `active` if was previously set to `stop` or `undeliverable`.
 
+- [Voter Registration Status](/#voter-registration-status)
+
 ### Online Drives
 
 Online drives is one of the tactics we have for getting people to get their friends registered to vote. For example, someone would sign up for the campaign and they have their own personal registration page (w/ a RTV form on it w/ the same kind of tracking) that they share with their friends/family. The appeal for them is that on their campaign action page, it will show how many people has viewed their personal registration page (v2 feature enhancement might be upping this to show who has registered).

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -102,17 +102,23 @@ If an existing user has a null `mobile` profile field and provides a phone numbe
 - We do **not** override an existing phone number.
 - We save a user's mobile number regardless of whether they opt-in to SMS messaging from DS.
 
-### SMS Status
+### Email Subscription
 
-If an existing user **opts-in** to voting-related SMS messaging from DS via RTV form, we update `sms_status` as `active` if current value is either null, `less`, `stop`, or `undeliverable`.
+Email subscriptions are not updated.
 
-If an existing user **opts-out** of voting-related SMS messaging from DS via RTV form, we update `sms_status` as `stop` if current value is null or `undeliverable`.
+### SMS Subscription
 
-### SMS Subscription Topics
+If an existing user **opts-in** to voting-related SMS messaging from DS:
 
-If an existing user **opts-in** to voting-related SMS messaging from DS via RTV form, we add the `voting` topic to their `sms_subscription_topics` if it doesn't exist.
+- add the `voting` topic to `sms_subscription_topics` if it doesn't exist.
 
-If an existing user **opts-out** of voting-related SMS messaging from DS via RTV form, we remove the `voting` topic from their `sms_subscription_topics` if it exists.
+- update `sms_status` as `active` if current value is either null, `less`, `stop`, or `undeliverable`.
+
+If an existing user **opts-out** of voting-related SMS messaging from DS:
+
+- remove the `voting` topic from `sms_subscription_topics` if it exists.
+
+- update `sms_status` as `stop` if current value is null or `undeliverable`.
 
 ## New Users
 
@@ -122,11 +128,11 @@ If the referral column doesn't have a NS ID, we try to find to a user by email, 
 
 - Address, City, Zip
 
-- Email
+- Email Subscription
 
   - If user opts-in to email messaging from DS, user is subscribed with `community` topic and an Activate Account email is sent.
 
-- Mobile
+- SMS Subscription
 
   - If user opts-in to SMS messging from DS, user is subscribed to the `voting` SMS topic with status `active`.
 

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -134,9 +134,9 @@ If the referral column doesn't have a NS ID, we try to find to a user by email, 
 
 - SMS Subscription
 
-  - If user opts-in to SMS messging from DS, user is subscribed to the `voting` SMS topic with status `active`.
+  - If user opts-in to SMS messaging from DS, user is subscribed to the `voting` SMS topic with status `active`.
 
-  - If user opts-out of SMS messging from DS, user's `sms_status` will be set to `stop` and `sms_subscription_topics` will be set to empty.
+  - If user opts-out of SMS messaging from DS, user's `sms_status` will be set to `stop` and `sms_subscription_topics` will be set to empty.
 
 - Voter Registration Status
 

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -144,7 +144,7 @@ If the referral column doesn't have a NS ID, we try to find to a user by email, 
 
 Online drives is one of the tactics we have for getting people to get their friends registered to vote. For example, someone would sign up for the campaign and they have their own personal registration page (w/ a RTV form on it w/ the same kind of tracking) that they share with their friends/family. The appeal for them is that on their campaign action page, it will show how many people has viewed their personal registration page (v2 feature enhancement might be upping this to show who has registered).
 
-So, the Alpha sends their page to a Beta and they register. The Alpha's referral links look like this: https://vote.dosomething.org/member-drive?userId={userId}&r=user:{userId},campaign:{campaignID},campaignRunID={campaignRunID},source=web,source_details=onlinedrivereferral,referral=true
+So, the Alpha sends their page to a Beta and they register. The Alpha's referral links look like this: https://vote.dosomething.org/member-drive?userId={userId}&r=user:{userId},source=web,source_details=onlinedrivereferral,referral=true
 
 We've added `referral=true` to the link so that we can know to not attribute the registration to the NS ID that is present in the URL. In this case, this NS ID is the referrer and not the registrant.
 

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -116,7 +116,14 @@ If an existing user **opts-out** of voting-related SMS messaging from DS via RTV
 
 ## New Users
 
-If the referral column doesn't have a NS ID, we try to find to a user by email, and last by mobile number. If a user is still not found, then create a NS account for them with the PII provided from Rock The Vote.
+If the referral column doesn't have a NS ID, we try to find to a user by email, and last by mobile number. If a user is still not found, then create a NS account for them with PII provided from Rock The Vote:
+
+- First Name
+- Last Name
+- Street Address, City, Zip
+- Mobile
+
+Note: We do not import the user's birthdate.
 
 ### Online Drives
 

--- a/docs/imports/rock-the-vote.md
+++ b/docs/imports/rock-the-vote.md
@@ -71,6 +71,8 @@ In this case, we would want to count the form completion (`register-form`). Itâ€
 
 If an existing User is found using the NS ID, email, or number, we may update the user's `voter_registration_status` or SMS preferences based on the new values from the record.
 
+Note: We do not update any PII for an existing user (except for a mobile, if we do not have one saved already).
+
 ### Voter Registration Status
 
 If there's an existing status on the user, we follow the same hierarchy rules established above but check for a few additional statuses:
@@ -123,7 +125,7 @@ If the referral column doesn't have a NS ID, we try to find to a user by email, 
 - Street Address, City, Zip
 - Mobile
 
-Note: We do not import the user's birthdate.
+Note: We do not import the user's birthdate, likely for [privacy concerns](https://dosomething.slack.com/archives/CTVPG6L4R/p1587153485493600?thread_ts=1587153236.493300&cid=CTVPG6L4R).
 
 ### Online Drives
 

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -26,3 +26,7 @@
   cursor: inherit;
   display: block;
 }
+.container-fluid {
+  padding-left: 0;
+  padding-right: 0;
+}

--- a/resources/views/pages/partials/rock-the-vote/create.blade.php
+++ b/resources/views/pages/partials/rock-the-vote/create.blade.php
@@ -5,7 +5,25 @@
     <div class="col-sm-9">
         <p class="form-control-static"><code>{{ $config['user']['email_subscription_topics'] }}</code></p>
         <small class="form-text text-muted">
-          The email subscription topics to subscribe new users to, if they have opted in to receive emails.
+          The email subscription topics to subscribe new users to, if they have opted-in to receive emails from DS.
+        </small>
+    </div>
+</div>
+<div class="form-group row">
+    <label class="col-sm-3 col-form-label">SMS subscription topics</label>
+    <div class="col-sm-9">
+        <p class="form-control-static"><code>{{ $config['user']['sms_subscription_topics'] }}</code></p>
+        <small SMS="form-text text-muted">
+          The SMS subscription topics to subscribe new users to, if they have opted-in to receive texts from DS.
+        </small>
+    </div>
+</div>
+<div class="form-group row">
+    <label class="col-sm-3 col-form-label">Update SMS subscriptions</label>
+    <div class="col-sm-9">
+        <p class="form-control-static">{{ $config['update_user_sms_enabled'] ? 'ON' : 'OFF'  }}</p>
+        <small class="form-text text-muted">
+          If this is ON, an existing user's SMS subscription will be updated per whether they opted-in to <a href="https://github.com/DoSomething/chompy/blob/master/docs/imports/rock-the-vote.md#mobile" target="_blank">receive texts from DS</a>.
         </small>
     </div>
 </div>
@@ -19,7 +37,7 @@
     </div>
 </div>
 <div class="form-group row">
-    <label class="col-sm-3 col-form-label">Send Password Reset</label>
+    <label class="col-sm-3 col-form-label">Send activate account email</label>
     <div class="col-sm-9">
         <p class="form-control-static">{{ $config['reset']['enabled'] ? 'ON' : 'OFF' }}</p>
         <small class="form-text text-muted">
@@ -28,7 +46,7 @@
     </div>
 </div>
 <div class="form-group row">
-    <label class="col-sm-3 col-form-label">Password Reset Type</label>
+    <label class="col-sm-3 col-form-label">Activate account email template</label>
     <div class="col-sm-9">
         <p class="form-control-static"><code>{{ $config['reset']['type'] }}</code></p>
         <small class="form-text text-muted">
@@ -36,15 +54,7 @@
         </small>
     </div>
 </div>
-<div class="form-group row">
-    <label class="col-sm-3 col-form-label">Update SMS Subscription</label>
-    <div class="col-sm-9">
-        <p class="form-control-static">{{ $config['update_user_sms_enabled'] ? 'ON' : 'OFF'  }}</p>
-        <small class="form-text text-muted">
-          If this is ON, an existing user's SMS subscription will be updated per their <a href="https://github.com/DoSomething/chompy/blob/master/docs/imports/rock-the-vote.md#mobile" target="_blank">voter registration</a>.
-        </small>
-    </div>
-</div>
+
 <h4>Posts</h4>
 <div class="form-group row">
     <label class="col-sm-3 col-form-label">Action ID</label>

--- a/resources/views/pages/partials/rock-the-vote/test.blade.php
+++ b/resources/views/pages/partials/rock-the-vote/test.blade.php
@@ -36,7 +36,7 @@
   </div>
   <label for="mobile" class="col-sm-3 col-form-label">Mobile</label>
   <div class="col-sm-3">
-    <input type="text" class="form-control" name="mobile" value="{{ old('mobile') }}">
+    {!! Form::text('mobile', $data['mobile'], ['class' => 'form-control']) !!}
   </div>
 </div>
 <div class="form-group row">
@@ -55,6 +55,9 @@
   <label for="referral" class="col-sm-3 col-form-label" required>Referral</label>
   <div class="col-sm-9">
     {!! Form::text('referral', $data['referral'], ['class' => 'form-control']) !!}
+      <small class="form-text text-muted">
+        The `r` query string value sent, e.g. <code>&r=user:5e9a3c0c9454f2503d3f36d2,source=web,source_details=puppetSlothArchive</code>. See <a href="https://github.com/DoSomething/chompy/blob/master/docs/imports/rock-the-vote.md#online-drives">docs</a>.
+      </small>
   </div>
 </div>
 <div class="form-group row">

--- a/resources/views/pages/partials/rock-the-vote/test.blade.php
+++ b/resources/views/pages/partials/rock-the-vote/test.blade.php
@@ -34,9 +34,9 @@
   <div class="col-sm-3">
     {!! Form::text('email', $data['email'], ['class' => 'form-control']) !!}
   </div>
-  <label for="mobile" class="col-sm-3 col-form-label">Mobile</label>
+  <label for="phone" class="col-sm-3 col-form-label">Phone</label>
   <div class="col-sm-3">
-    {!! Form::text('mobile', $data['mobile'], ['class' => 'form-control']) !!}
+    {!! Form::text('phone', $data['phone'], ['class' => 'form-control']) !!}
   </div>
 </div>
 <div class="form-group row">
@@ -52,9 +52,9 @@
 
 <h3>Voter Registration</h3>
 <div class="form-group row">
-  <label for="referral" class="col-sm-3 col-form-label" required>Tracking Source</label>
+  <label for="tracking_source" class="col-sm-3 col-form-label" required>Tracking Source</label>
   <div class="col-sm-9">
-    {!! Form::text('referral', $data['referral'], ['class' => 'form-control']) !!}
+    {!! Form::text('tracking_source', $data['tracking_source'], ['class' => 'form-control']) !!}
       <small class="form-text text-muted">
         The `r` query string value sent, e.g. <code>vote.dosomething.org?r=user:5e9a3c0c9454f2503d3f36d2,source=web,source_details=puppetSlothArchive</code>. See <a href="https://github.com/DoSomething/chompy/blob/master/docs/imports/rock-the-vote.md#online-drives">docs</a>.
       </small>

--- a/resources/views/pages/partials/rock-the-vote/test.blade.php
+++ b/resources/views/pages/partials/rock-the-vote/test.blade.php
@@ -56,7 +56,7 @@
   <div class="col-sm-9">
     {!! Form::text('referral', $data['referral'], ['class' => 'form-control']) !!}
       <small class="form-text text-muted">
-        The `r` query string value sent, e.g. <code>&r=user:5e9a3c0c9454f2503d3f36d2,source=web,source_details=puppetSlothArchive</code>. See <a href="https://github.com/DoSomething/chompy/blob/master/docs/imports/rock-the-vote.md#online-drives">docs</a>.
+        The `r` query string value sent, e.g. <code>vote.dosomething.org?r=user:5e9a3c0c9454f2503d3f36d2,source=web,source_details=puppetSlothArchive</code>. See <a href="https://github.com/DoSomething/chompy/blob/master/docs/imports/rock-the-vote.md#online-drives">docs</a>.
       </small>
   </div>
 </div>

--- a/resources/views/pages/partials/rock-the-vote/test.blade.php
+++ b/resources/views/pages/partials/rock-the-vote/test.blade.php
@@ -52,7 +52,7 @@
 
 <h3>Voter Registration</h3>
 <div class="form-group row">
-  <label for="referral" class="col-sm-3 col-form-label" required>Referral</label>
+  <label for="referral" class="col-sm-3 col-form-label" required>Tracking Source</label>
   <div class="col-sm-9">
     {!! Form::text('referral', $data['referral'], ['class' => 'form-control']) !!}
       <small class="form-text text-muted">


### PR DESCRIPTION
### What's this PR do?

This pull request addresses two items flagged in #157:

* Removes debugging a `$user` object, as the mystery was solved in https://github.com/DoSomething/northstar/pull/1010

* Clarifies which user fields are and are not imported via import (I thought we mistakenly stopped importing birthdate during the many surgeries this import has undergone)

### How should this be reviewed?

👀 

### Any background context you want to provide?

🪑 

### Relevant tickets

References [Pivotal #171848124](https://www.pivotaltracker.com/n/projects/2417735/stories/171848124).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
