### PR TITLE
Adds feature flag for Import Test form, environment-badge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,9 @@ FILESYSTEM_DRIVER=local
 ROCK_THE_VOTE_API_KEY=
 ROCK_THE_VOTE_PARTNER_ID=
 
+# Chompy UI configuration
+IMPORT_TEST_FORM_ENABLED=true
+
 ##
 ## Optional config overrides - Email Subscription Import
 ##
@@ -80,6 +83,9 @@ NEWS_SUBSCRIPTION_RESET_TYPE=breakdown-activate-account
 ##
 ## Optional config overrides - Rock The Vote Import
 ##
+
+# Whether to update existing users' SMS subscriptions per opt-in via RTV registration form.
+ROCK_THE_VOTE_UPDATE_USER_SMS_ENABLED=false
 
 # The action id to get/create a post for.
 ROCK_THE_VOTE_POST_ACTION_ID=850

--- a/config/import.php
+++ b/config/import.php
@@ -1,6 +1,9 @@
 <?php
 
 return [
+    // Whether to display the Test Import form within the Chompy UI.
+    'import_test_form_enabled' => env('IMPORT_TEST_FORM_ENABLED', 'false'),
+    // Configuration for an email subscription import.
     'email_subscription' => [
         'topics' => [
             'community' => [
@@ -29,6 +32,7 @@ return [
             ],
         ],
     ],
+    // Configuration for a Rock The Vote voter registration import.
     'rock_the_vote' => [
         // Constants to use when creating a post.
         'post' => [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1109,7 +1109,7 @@
     },
     "adjust-sourcemap-loader": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-1.2.0.tgz",
       "integrity": "sha512-958oaHHVEXMvsY7v7cC5gEkNIcoaAVIhZ4mBReYVZJOTP9IgKmzLjIOhTtzpLMu+qriXvLsVjJ155EeInp45IQ==",
       "dev": true,
       "requires": {
@@ -1408,7 +1408,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1682,7 +1682,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -1719,7 +1719,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -2321,6 +2321,11 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+    },
     "core-js-compat": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
@@ -2376,7 +2381,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -2389,7 +2394,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2471,7 +2476,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -2910,7 +2915,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -3089,6 +3094,14 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
+    },
+    "environment-badge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/environment-badge/-/environment-badge-1.3.1.tgz",
+      "integrity": "sha512-IrpwhWvroyh/gXXjrxz3WU2jR8YEexmhKbBp27K41qur7klBYjxaXj654xj8lK0lwt0XkwFjCs3vDH9Wd2n2XA==",
+      "requires": {
+        "core-js": "^3.1.3"
+      }
     },
     "errno": {
       "version": "0.1.7",
@@ -3742,7 +3755,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5202,7 +5215,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -5713,7 +5726,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -5912,7 +5925,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -6643,7 +6656,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -7671,7 +7684,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -7962,7 +7975,7 @@
       "dependencies": {
         "convert-source-map": {
           "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
           "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
           "dev": true
         }
@@ -8283,7 +8296,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -8818,7 +8831,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -8995,7 +9008,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "vue-template-compiler": "^2.6.10"
   },
   "dependencies": {
+    "environment-badge": "^1.3.1",
     "laravel-echo": "^1.5.4",
     "pusher-js": "^4.2.2"
   }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1,3 +1,5 @@
+require('environment-badge')();
+
 // Set up JS
 import './bootstrap';
 
@@ -6,4 +8,3 @@ import './uploadForm';
 
 // Handles updating the progress bar
 import './progress';
-

--- a/resources/views/pages/import-files/test.blade.php
+++ b/resources/views/pages/import-files/test.blade.php
@@ -10,20 +10,20 @@
         Use this form to test importing a <code>{{$importType}}</code> record.
     <p>
     @if (config('import.import_test_form_enabled') == 'true')
-    <div>
-        <form action={{ route('import.store', ['importType' => $importType]) }} method="post" enctype="multipart/form-data">
-            {{ csrf_field() }}
-            @if ($importType === \Chompy\ImportType::$rockTheVote)
-                @include('pages.partials.rock-the-vote.test')
-                <div>
-                    <input type="submit" class="btn btn-primary btn-lg" value="Submit">
-                </div>
-                @include('pages.partials.rock-the-vote.create', ['config' => $config])
-            @endif
-        </form>
-    </div>
+        <div>
+            <form action={{ route('import.store', ['importType' => $importType]) }} method="post" enctype="multipart/form-data">
+                {{ csrf_field() }}
+                @if ($importType === \Chompy\ImportType::$rockTheVote)
+                    @include('pages.partials.rock-the-vote.test')
+                    <div>
+                        <input type="submit" class="btn btn-primary btn-lg" value="Submit">
+                    </div>
+                    @include('pages.partials.rock-the-vote.create', ['config' => $config])
+                @endif
+            </form>
+        </div>
     @else
-    <p>This feature is currently disabled.</p>
+        <p>This feature is currently disabled.</p>
     @endif
 
 </div>

--- a/resources/views/pages/import-files/test.blade.php
+++ b/resources/views/pages/import-files/test.blade.php
@@ -9,6 +9,7 @@
     <p>
         Use this form to test importing a <code>{{$importType}}</code> record.
     <p>
+    @if (config('import.import_test_form_enabled') == 'true')
     <div>
         <form action={{ route('import.store', ['importType' => $importType]) }} method="post" enctype="multipart/form-data">
             {{ csrf_field() }}
@@ -21,6 +22,9 @@
             @endif
         </form>
     </div>
+    @else
+    <p>This feature is currently disabled.</p>
+    @endif
 
 </div>
 

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -13,6 +13,14 @@ use DoSomething\Gateway\Resources\NorthstarUser;
 class ImportRockTheVoteRecordTest extends TestCase
 {
     /**
+     * Set or unset the Update User SMS Subscription feature flag.
+     */
+    private function enableUpdateUserSmsFeature(bool $shouldUpdate)
+    {
+        \Config::set('import.rock_the_vote.update_user_sms_enabled', $shouldUpdate ? 'true' : 'false');
+    }
+
+    /**
      * Test that user and post are created if user not found.
      *
      * @return void
@@ -126,6 +134,8 @@ class ImportRockTheVoteRecordTest extends TestCase
      */
     public function testUpdatesUserIfShouldChangeStatus()
     {
+        $this->enableUpdateUserSmsFeature(false);
+
         $userId = $this->faker->northstar_id;
         $startedRegistration = $this->faker->daysAgoInRockTheVoteFormat();
         $postId = $this->faker->randomDigitNotNull;
@@ -186,6 +196,8 @@ class ImportRockTheVoteRecordTest extends TestCase
      */
     public function testUserUpdatePayloadDoesNotContainMobileIfUpdateUserSmsConfigIsDisabled()
     {
+        $this->enableUpdateUserSmsFeature(false);
+
         $user = new NorthstarUser([
             'id' => $this->faker->northstar_id,
             'voter_registration_status' => 'step-1',
@@ -216,7 +228,7 @@ class ImportRockTheVoteRecordTest extends TestCase
      */
     public function testUserUpdatePayloadContainsMobileIfUpdateUserSmsConfigIsEnabled()
     {
-        \Config::set('import.rock_the_vote.update_user_sms_enabled', 'true');
+        $this->enableUpdateUserSmsFeature(true);
 
         $user = new NorthstarUser([
             'id' => $this->faker->northstar_id,
@@ -245,7 +257,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job->updateUserIfChanged($user);
 
-        \Config::set('import.rock_the_vote.update_user_sms_enabled', 'false');
+        $this->enableUpdateUserSmsFeature(false);
     }
 
     /**

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -245,20 +245,18 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $this->northstarMock
-            ->shouldReceive('updateUser')
-            ->with($user->id, [
-                'mobile' => $phoneNumber,
-                'sms_status' => SmsStatus::$active,
-                'sms_subscription_topics' => ['voting'],
-                'voter_registration_status' => 'step-2',
-            ])->andReturn(new NorthstarUser([
-                'id' => $user->id,
-                'mobile' => $phoneNumber,
-                'sms_status' => SmsStatus::$active,
-                'sms_subscription_topics' => ['voting'],
-                'voter_registration_status' => 'step-2',
-            ]));
+        $this->northstarMock->shouldReceive('updateUser')->with($user->id, [
+            'mobile' => $phoneNumber,
+            'sms_status' => SmsStatus::$active,
+            'sms_subscription_topics' => ['voting'],
+            'voter_registration_status' => 'step-2',
+        ])->andReturn(new NorthstarUser([
+            'id' => $user->id,
+            'mobile' => $phoneNumber,
+            'sms_status' => SmsStatus::$active,
+            'sms_subscription_topics' => ['voting'],
+            'voter_registration_status' => 'step-2',
+        ]));
 
         $job->updateUserIfChanged($user);
     }


### PR DESCRIPTION
### What's this PR do?

This pull request branches off of #159 to add a new config variable to disable the Import Test form -- we shouldn't have this enabled on production by default. It also adds our in-house [environment-badge](https://github.com/DoSomething/environment-badge), which is very exciting as someone who spends quite a bit of time in Chompy these days.

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

Begins to start cleaning up some of the `ImportRockTheVoteRecord` tests -- as we're looking to enable the `ROCK_THE_VOTE_UPDATE_USER_SMS_ENABLED` soon.

### Relevant tickets

References [Pivotal #171848124](https://www.pivotaltracker.com/story/show/171848124).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
