### PR TITLE
Tests for updating an existing user's SMS subscription

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -76,7 +76,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
             $this->importFile->incrementSkipCount();
 
-            return;
+            return [];
         }
 
         $user = $this->updateUserIfChanged($user);

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -332,10 +332,18 @@ class ImportRockTheVoteRecord implements ShouldQueue
     {
         $fieldName = 'sms_subscription_topics';
         $currentSmsTopics = ! empty($user->{$fieldName}) ? $user->{$fieldName} : [];
+        $updatedSmsTopics = [];
 
         // If user opted in to SMS, add the import topics to current topics.
         if ($this->smsOptIn) {
-            return [$fieldName => array_unique(array_merge($currentSmsTopics, $this->userData[$fieldName]))];
+            $updatedSmsTopics =  array_unique(array_merge($currentSmsTopics, $this->userData[$fieldName]));
+
+            // If we didn't add any new topics, nothing to update.
+            if (count($updatedSmsTopics) === count($currentSmsTopics)) {
+                return [];
+            }
+
+            return [$fieldName => $updatedSmsTopics];
         }
 
         // Nothing to remove if current topics in empty.
@@ -344,8 +352,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
         }
 
         // If user hasn't opted-in and has current topics, remove all import topics from current.
-        $updatedSmsTopics = [];
-
         foreach ($currentSmsTopics as $topic) {
             if (! in_array($topic, explode(',', config('import.rock_the_vote.user.sms_subscription_topics')))) {
                 array_push($updatedSmsTopics, $topic);

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -266,6 +266,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
             info('Checking for SMS subscription updates', ['user' => $user->id]);
 
             $payload = array_merge($payload, $this->getUserSmsSubscriptionUpdatePayload($user));
+            info('Test payload', $payload);
         }
 
         if (! count($payload)) {

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -314,7 +314,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function parseMobileChangeForUser(NorthstarUser $user)
     {
-        info('parseMobileChangeForUser');
         $fieldName = 'mobile';
 
         if ($user->{$fieldName}) {
@@ -331,10 +330,8 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function parseSmsSubscriptionTopicsChangeForUser(NorthstarUser $user)
     {
-        info('parseSmsSubscriptionTopicsChangeForUser');
         $fieldName = 'sms_subscription_topics';
         $currentSmsTopics = ! empty($user->{$fieldName}) ? $user->{$fieldName} : [];
-        info('test', $currentSmsTopics ? $currentSmsTopics : ['null']);
         $updatedSmsTopics = [];
 
         // If user opted in to SMS, add the import topics to current topics.

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -266,7 +266,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
             info('Checking for SMS subscription updates', ['user' => $user->id]);
 
             $payload = array_merge($payload, $this->getUserSmsSubscriptionUpdatePayload($user));
-            info('Test payload', $payload);
         }
 
         if (! count($payload)) {

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -314,6 +314,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function parseMobileChangeForUser(NorthstarUser $user)
     {
+        info('parseMobileChangeForUser');
         $fieldName = 'mobile';
 
         if ($user->{$fieldName}) {
@@ -330,13 +331,15 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function parseSmsSubscriptionTopicsChangeForUser(NorthstarUser $user)
     {
+        info('parseSmsSubscriptionTopicsChangeForUser');
         $fieldName = 'sms_subscription_topics';
         $currentSmsTopics = ! empty($user->{$fieldName}) ? $user->{$fieldName} : [];
+        info('test', $currentSmsTopics ? $currentSmsTopics : ['null']);
         $updatedSmsTopics = [];
 
         // If user opted in to SMS, add the import topics to current topics.
         if ($this->smsOptIn) {
-            $updatedSmsTopics =  array_unique(array_merge($currentSmsTopics, $this->userData[$fieldName]));
+            $updatedSmsTopics = array_unique(array_merge($currentSmsTopics, $this->userData[$fieldName]));
 
             // If we didn't add any new topics, nothing to update.
             if (count($updatedSmsTopics) === count($currentSmsTopics)) {

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -533,12 +533,6 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * -----------------------------------
-     * getUserSmsSubscriptionUpdatePayload
-     * -----------------------------------
-     */
-
-    /**
      * Return mock user and row that do not have voter registration changes for a
      * SmsSubscriptionUpdate test.
      *
@@ -546,7 +540,7 @@ class ImportRockTheVoteRecordTest extends TestCase
      * @param bool @rtvSmsOptIn
      * @return obj
      */
-    public function getMocksForParseSmsStatusChangeTest($currentSmsStatus, bool $rtvSmsOptIn)
+    public function getMocksForUpdateUserSmsTest($currentSmsStatus, bool $rtvSmsOptIn)
     {
         $user = new NorthstarUser([
             'id' => $this->faker->northstar_id,
@@ -573,7 +567,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(null, true);
+        $mocks = $this->getMocksForUpdateUserSmsTest(null, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -595,7 +589,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(null, false);
+        $mocks = $this->getMocksForUpdateUserSmsTest(null, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -616,7 +610,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$active, true);
+        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$active, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         // Nothing to update, user already has 'voting' topic.
@@ -634,7 +628,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$active, false);
+        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$active, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -656,7 +650,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$less, true);
+        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$less, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -678,7 +672,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$less, false);
+        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$less, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -700,7 +694,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$pending, true);
+        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$pending, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -722,7 +716,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$pending, false);
+        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$pending, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -744,7 +738,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$stop, true);
+        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$stop, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -766,7 +760,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$stop, false);
+        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$stop, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldNotReceive('updateUser');
@@ -783,7 +777,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$undeliverable, true);
+        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$undeliverable, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -805,7 +799,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     {
         $this->enableUpdateUserSmsFeature(true);
 
-        $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$undeliverable, false);
+        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$undeliverable, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -568,7 +568,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(null, true);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
@@ -577,9 +576,9 @@ class ImportRockTheVoteRecordTest extends TestCase
           ])
           ->andReturn($mocks->user);
 
-        $job->updateUserIfChanged($mocks->user);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**
@@ -590,7 +589,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(null, false);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
@@ -598,9 +596,9 @@ class ImportRockTheVoteRecordTest extends TestCase
           ])
           ->andReturn($mocks->user);
 
-        $job->updateUserIfChanged($mocks->user);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**
@@ -611,14 +609,13 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$active, true);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
-
+ 
         // Nothing to update, user already has 'voting' topic.
         $this->northstarMock->shouldNotReceive('updateUser');
 
-        $job->updateUserIfChanged($mocks->user);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**
@@ -629,7 +626,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$active, false);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
@@ -638,9 +634,9 @@ class ImportRockTheVoteRecordTest extends TestCase
           ])
           ->andReturn($mocks->user);
 
-        $job->updateUserIfChanged($mocks->user);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**
@@ -651,7 +647,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$less, true);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
@@ -660,9 +655,9 @@ class ImportRockTheVoteRecordTest extends TestCase
           ])
           ->andReturn($mocks->user);
 
-        $job->updateUserIfChanged($mocks->user);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**
@@ -673,7 +668,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$less, false);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
@@ -682,9 +676,9 @@ class ImportRockTheVoteRecordTest extends TestCase
           ])
           ->andReturn($mocks->user);
 
-        $job->updateUserIfChanged($mocks->user);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**
@@ -695,7 +689,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$pending, true);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
@@ -704,9 +697,9 @@ class ImportRockTheVoteRecordTest extends TestCase
           ])
           ->andReturn($mocks->user);
 
-        $job->updateUserIfChanged($mocks->user);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**
@@ -717,8 +710,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$pending, false);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
-
+ 
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
               // Status not changed, but 'voting' topic should be removed.
@@ -726,9 +718,9 @@ class ImportRockTheVoteRecordTest extends TestCase
           ])
           ->andReturn($mocks->user);
 
-        $job->updateUserIfChanged($mocks->user);
+       $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+       $job->updateUserIfChanged($mocks->user);
     }
 
     /**
@@ -739,7 +731,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$stop, true);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
@@ -748,9 +739,9 @@ class ImportRockTheVoteRecordTest extends TestCase
           ])
           ->andReturn($mocks->user);
 
-        $job->updateUserIfChanged($mocks->user);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**
@@ -761,13 +752,12 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$stop, false);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldNotReceive('updateUser');
 
-        $job->updateUserIfChanged($mocks->user);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**
@@ -778,7 +768,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$undeliverable, true);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
@@ -787,9 +776,9 @@ class ImportRockTheVoteRecordTest extends TestCase
           ])
           ->andReturn($mocks->user);
 
-        $job->updateUserIfChanged($mocks->user);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**
@@ -800,7 +789,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$undeliverable, false);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
@@ -808,9 +796,9 @@ class ImportRockTheVoteRecordTest extends TestCase
           ])
           ->andReturn($mocks->user);
 
-        $job->updateUserIfChanged($mocks->user);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(false);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -606,51 +606,50 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Tests that update is empty if user with active value opts-out.
-     *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasActiveSmsStatusAndOptsOut()
+    public function testUserSmsSubscriptionUpdateIfUserHasActiveSmsStatusAndOptsOut()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$active, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
 
-        $this->assertEquals([], $result);
+        $this->assertEquals([
+            // The 'voting' topic should be removed.
+            'sms_subscription_topics' => ['general'],
+        ], $result);
     }
 
     /**
-     * Test that SMS status is updated to active if user with less value opts-in
-     *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasLessSmsStatusAndOptsIn()
+    public function testUserSmsSubscriptionUpdateIfUserHasLessSmsStatusAndOptsIn()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$less, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
 
+        // Topics not changed, since user already had 'voting' topic set.
         $this->assertEquals(['sms_status' => SmsStatus::$active], $result);
     }
 
     /**
-     * Test that update is empty if user with less value opts-out.
-     *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasLessSmsStatusAndOptsOut()
+    public function testUserSmsSubscriptionUpdateIfUserHasLessSmsStatusAndOptsOut()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$less, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
 
-        $this->assertEquals([], $result);
+        // Status should not change, but 'voting' topic should be removed.
+        $this->assertEquals(['sms_subscription_topics' => ['general']], $result);
     }
 
-    /**
+    /**`
      * Test that SMS status is updated to active if user with pending value opts-in.
      *
      * @return void

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -533,9 +533,9 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * ---------------------------
-     * parseSmsStatusChangeForUser
-     * ---------------------------
+     * -----------------------------------
+     * getUserSmsSubscriptionUpdatePayload
+     * -----------------------------------
      */
 
     /**
@@ -551,6 +551,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             'id' => $this->faker->northstar_id,
             'mobile' => $this->faker->phoneNumber,
             'sms_status' => $currentSmsStatus,
+            'sms_subscription_topics' => in_array($currentSmsStatus, [SmsStatus::$active, SmsStatus::$less, SmsStatus::$pending]) ? ['general', 'voting'] : [],
         ]);
         $row = $this->faker->rockTheVoteReportRow([
             RockTheVoteRecord::$mobileFieldName => $this->faker->phoneNumber,
@@ -561,46 +562,45 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Tests SMS status is updated to active if user with null value opts-in.
-     *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasNullSmsStatusAndOptsIn()
+    public function testUserSmsSubscriptionUpdateIfUserHasNullSmsStatusAndOptsIn()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(null, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
 
-        $this->assertEquals(['sms_status' => SmsStatus::$active], $result);
+        $this->assertEquals([
+            'sms_status' => SmsStatus::$active,
+            'sms_subscription_topics' => ['voting'],
+        ], $result);
     }
 
     /**
-     * Tests SMS status is updated to stop if user with null value opts-out.
-     *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasNullSmsStatusAndOptsOut()
+    public function testUserSmsSubscriptionUpdateIfUserHasNullSmsStatusAndOptsOut()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(null, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
 
-        $this->assertEquals(['sms_status' => SmsStatus::$stop], $result);
+        $this->assertEquals([
+            'sms_status' => SmsStatus::$stop,
+        ], $result);
     }
 
     /**
-     * Tests that update is empty if user with active value opts-in.
-     *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasActiveSmsStatusAndOptsIn()
+    public function testUserSmsSubscriptionUpdateIfUserHasActiveSmsStatusAndOptsIn()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$active, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
 
         $this->assertEquals([], $result);
     }

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -649,93 +649,89 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->assertEquals(['sms_subscription_topics' => ['general']], $result);
     }
 
-    /**`
-     * Test that SMS status is updated to active if user with pending value opts-in.
-     *
+    /**
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasPendingSmsStatusAndOptsIn()
+    public function testUserSmsSubscriptionUpdateIfUserHasPendingSmsStatusAndOptsIn()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$pending, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
 
+        // Status should change, don't update topics because user already has 'voting' topic.
         $this->assertEquals(['sms_status' => SmsStatus::$active], $result);
     }
 
     /**
-     * Test that update is empty if user with pending value opts-out.
-     *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasPendingSmsStatusAndOptsOut()
+    public function testUserSmsSubscriptionUpdateIfUserHasPendingSmsStatusAndOptsOut()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$pending, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
 
-        $this->assertEquals([], $result);
+        // Status should not change, but 'voting' topic should be removed.
+        $this->assertEquals(['sms_subscription_topics' => ['general']], $result);
     }
 
     /**
-     * Test that SMS status is updated to active if user with stop value opts-in.
-     *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasStopSmsStatusAndOptsIn()
+    public function testUserSmsSubscriptionUpdateIfUserHasStopSmsStatusAndOptsIn()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$stop, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
 
-        $this->assertEquals(['sms_status' => SmsStatus::$active], $result);
+        $this->assertEquals([
+            'sms_status' => SmsStatus::$active,
+            'sms_subscription_topics' => ['voting'],
+        ], $result);
     }
 
     /**
-     * Test that update is empty if user with stop value opts-out.
-     *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasStopSmsStatusAndOptsOut()
+    public function testUserSmsSubscriptionUpdateIfUserHasStopSmsStatusAndOptsOut()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$stop, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
 
         $this->assertEquals([], $result);
     }
 
     /**
-     * Tests SMS status is updated to active if user with undeliverable value opts-in to RTV SMS.
-     *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasUndeliverableSmsStatusAndOptsIn()
+    public function testUserSmsSubscriptionUpdateIfUserHasUndeliverableSmsStatusAndOptsIn()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$undeliverable, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
 
-        $this->assertEquals(['sms_status' => SmsStatus::$active], $result);
+        $this->assertEquals([
+            'sms_status' => SmsStatus::$active,
+            'sms_subscription_topics' => ['voting'],
+        ], $result);
     }
 
     /**
-     * Tests SMS status is updated to stop if user with undeliverable value opts-in to RTV SMS.
-     *
      * @return void
      */
-    public function testParseSmsStatusChangeIfUserHasUndeliverableSmsStatusAndOptsOut()
+    public function testUserSmsSubscriptionUpdateIfUserHasUndeliverableSmsStatusAndOptsOut()
     {
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$undeliverable, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->parseSmsStatusChangeForUser($mocks->user);
-
+        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
+ 
         $this->assertEquals(['sms_status' => SmsStatus::$stop], $result);
     }
 

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -749,8 +749,8 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
-            'sms_status' => SmsStatus::$active,
-            'sms_subscription_topics' => ['voting'],
+              'sms_status' => SmsStatus::$active,
+              'sms_subscription_topics' => ['voting'],
           ])
           ->andReturn($mocks->user);
 
@@ -779,30 +779,44 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testUserSmsSubscriptionUpdateIfUserHasUndeliverableSmsStatusAndOptsIn()
+    public function testEnabledUpdateUserSmsWhenUserHasUndeliverableSmsStatusAndOptsIn()
     {
+        $this->enableUpdateUserSmsFeature(true);
+
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$undeliverable, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
+        $this->northstarMock->shouldReceive('updateUser')
+          ->with($mocks->user->id, [
+              'sms_status' => SmsStatus::$active,
+              'sms_subscription_topics' => ['voting'],
+          ])
+          ->andReturn($mocks->user);
 
-        $this->assertEquals([
-            'sms_status' => SmsStatus::$active,
-            'sms_subscription_topics' => ['voting'],
-        ], $result);
+        $job->updateUserIfChanged($mocks->user);
+
+        $this->enableUpdateUserSmsFeature(false);
     }
 
     /**
      * @return void
      */
-    public function testUserSmsSubscriptionUpdateIfUserHasUndeliverableSmsStatusAndOptsOut()
+    public function testEnabledUpdateUserSmsWhenUserHasUndeliverableSmsStatusAndOptsOut()
     {
+        $this->enableUpdateUserSmsFeature(true);
+
         $mocks = $this->getMocksForParseSmsStatusChangeTest(SmsStatus::$undeliverable, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
+        $this->northstarMock->shouldReceive('updateUser')
+          ->with($mocks->user->id, [
+              'sms_status' => SmsStatus::$stop,
+          ])
+          ->andReturn($mocks->user);
 
-        $this->assertEquals(['sms_status' => SmsStatus::$stop], $result);
+        $job->updateUserIfChanged($mocks->user);
+
+        $this->enableUpdateUserSmsFeature(false);
     }
 
     /**

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -731,7 +731,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
         $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
- 
+
         $this->assertEquals(['sms_status' => SmsStatus::$stop], $result);
     }
 

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -609,7 +609,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$active, true);
- 
+
         // Nothing to update, user already has 'voting' topic.
         $this->northstarMock->shouldNotReceive('updateUser');
 
@@ -710,7 +710,7 @@ class ImportRockTheVoteRecordTest extends TestCase
         $this->enableUpdateUserSmsFeature(true);
 
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$pending, false);
- 
+
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
               // Status not changed, but 'voting' topic should be removed.
@@ -718,9 +718,9 @@ class ImportRockTheVoteRecordTest extends TestCase
           ])
           ->andReturn($mocks->user);
 
-       $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-       $job->updateUserIfChanged($mocks->user);
+        $job->updateUserIfChanged($mocks->user);
     }
 
     /**

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -814,6 +814,26 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testDisabledUpdateUserSmsWhenUserHasUndeliverableSmsStatusAndOptsIn()
+    {
+        /**
+         * The UpdateUserSms feature is currently disabled on production, but for local development
+         * we turn it on, in order to test the import.
+         */
+        $this->enableUpdateUserSmsFeature(false);
+
+        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$undeliverable, true);
+        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
+
+        // When UpdateUserSms is disabled, existing users can't resubscribe via import.
+        $this->northstarMock->shouldNotReceive('updateUser');
+
+        $job->updateUserIfChanged($mocks->user);
+    }
+
+    /**
      * ---------------------------------------
      * parseSmsSubscriptionTopicsChangeForUser
      * ---------------------------------------

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -814,26 +814,6 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * @return void
-     */
-    public function testDisabledUpdateUserSmsWhenUserHasUndeliverableSmsStatusAndOptsIn()
-    {
-        /**
-         * The UpdateUserSms feature is currently disabled on production, but for local development
-         * we turn it on, in order to test the import.
-         */
-        $this->enableUpdateUserSmsFeature(false);
-
-        $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$undeliverable, true);
-        $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
-
-        // When UpdateUserSms is disabled, existing users can't resubscribe via import.
-        $this->northstarMock->shouldNotReceive('updateUser');
-
-        $job->updateUserIfChanged($mocks->user);
-    }
-
-    /**
      * ---------------------------------------
      * parseSmsSubscriptionTopicsChangeForUser
      * ---------------------------------------

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -569,17 +569,17 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testUpdateUserIfUserHasNullSmsStatusAndOptsIn()
+    public function testEnabledUpdateUserSmsWhenUserHasNullSmsStatusAndOptsIn()
     {
+        $this->enableUpdateUserSmsFeature(true);
+
         $mocks = $this->getMocksForParseSmsStatusChangeTest(null, true);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $this->enableUpdateUserSmsFeature(true);
-
         $this->northstarMock->shouldReceive('updateUser')
           ->with($mocks->user->id, [
-            'sms_status' => SmsStatus::$active,
-            'sms_subscription_topics' => ['voting'],
+              'sms_status' => SmsStatus::$active,
+              'sms_subscription_topics' => ['voting'],
           ])
           ->andReturn($mocks->user);
 
@@ -591,16 +591,22 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testUserSmsSubscriptionUpdateIfUserHasNullSmsStatusAndOptsOut()
+    public function testEnabledUpdateUserSmsWhenUserHasNullSmsStatusAndOptsOut()
     {
+        $this->enableUpdateUserSmsFeature(true);
+
         $mocks = $this->getMocksForParseSmsStatusChangeTest(null, false);
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $result = $job->getUserSmsSubscriptionUpdatePayload($mocks->user);
+        $this->northstarMock->shouldReceive('updateUser')
+          ->with($mocks->user->id, [
+              'sms_status' => SmsStatus::$stop,
+          ])
+          ->andReturn($mocks->user);
 
-        $this->assertEquals([
-            'sms_status' => SmsStatus::$stop,
-        ], $result);
+        $job->updateUserIfChanged($mocks->user);
+
+        $this->enableUpdateUserSmsFeature(false);
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request refactors the many tests for `parseSmsStatusChangeForUser` function to instead test for the `updateUserIfChanged` function -- which has different behavior based on whether the `UPDATE_USER_SMS_ENABLED` config variable is set. Now that we're looking to enable updating the SMS subscriptions for existing users via the RTV import, it's ideal to test that `updateUserIfChanged` does change the SMS subscription for existing users as we'd expect to when the feature flag is enabled. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

There are so many different tests because the import will behave differently based on an existing user's SMS status, and whether they opt-in.

The groundwork for all of these tests was laid out by the `parseSmsStatus` tests, since that has the most variation -- so it felt like it made sense to refactor these unit tests as more of a general integration test for updating the user, to hopefully keep this PR readable/reviewable.

These tests rely on mocking calls to the Northstar API -- there's also a related [separate document for a human to manually QA each scenario](https://docs.google.com/document/d/1wKg33xbLdrnNaJyNH0vmBaUN_eSFyqd8Ug4f-CGXCHc/edit?usp=sharing), should that help provide background context. I'll be finishing up that doc as I manually test each scenario myself via the Import Test form (#157) 

### Relevant tickets

References [Pivotal #171848124](https://www.pivotaltracker.com/story/show/171848124).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
