### PR TITLE
Adds more checks for invalid phone numbers

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -49,5 +49,16 @@ function is_anonymous_mobile($mobile)
  */
 function is_valid_mobile($mobile)
 {
-    return $mobile != '000-000-0000';
+    // This phone number has been passed before and fails Northstar validation.
+    if ($mobile == '000-000-0000') {
+        return false;
+    }
+
+    /**
+     * Remove spaces and dashes and make sure there are at least 10 digits, e.g. "787 249 13" has
+     * been passed and fails Northstar validation.
+     */
+    $mobile = preg_replace("/[\s-]+/", '', $mobile);
+
+    return strlen($mobile) > 9;
 }

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -13,5 +13,7 @@ class HelpersTest extends TestCase
     {
         $this->assertEquals(is_valid_mobile('212-254-2390'), true);
         $this->assertEquals(is_valid_mobile('000-000-0000'), false);
+        $this->assertEquals(is_valid_mobile('787 249 13'), false);
+        $this->assertEquals(is_valid_mobile('302367890'), false);
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a rule to our super simple `is_valid_mobile` helper to return `false` if the phone number has less than 10 digits. There is a small number of failed jobs that have the format described in the example -- adding this change will allow these failed jobs to process, by creating the user without the provided mobile number.

### How should this be reviewed?

👀 

### Any background context you want to provide?

☎️ 

### Relevant tickets

#140 

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
