### PR TITLE
Encode failedJob parameters

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -101,7 +101,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
     {
         $result = [
             'user' => [],
-            'post' => Arr::only($post, ['id', 'type', 'action_id', 'status', 'details']),
+            'post' => Arr::only($post, ['id', 'type', 'action_id', 'status', 'details', 'referrer_user_id']),
         ];
 
         $userFields = ['id', 'email', 'mobile', 'voter_registration_status', 'sms_status', 'sms_subscription_topics', 'email_subscription_status', 'email_subscription_topics'];

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,9 +10,9 @@ Third-parties with authorized access can post data to the Chompy API. See [API d
 
 Chompy supports imports of two types of CSV:
 
-* Rock The Vote voter registrations
+- [Rock The Vote voter registrations](<(https://github.com/DoSomething/chompy/tree/master/docs/imports.md#rock-the-vote).>)
 
-* Email subscriptions to newsletters
+- Email subscriptions to newsletters
 
 Staff members may login to Chompy with their Northstar credentials, and select a CSV to import. The uploaded file is stored on S3, and then a [queue job](https://laravel.com/docs/5.6/queues) is pushed onto a Redis queue to import records from the CSV as users and/or activity.
 

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -159,3 +159,7 @@ If the referral column has `referral=true` in it, then proceed with the logic wi
 - In early iterations of the import, we would pass Campaign/Run IDs as parameters within the referral code to use when upsert a `voter-reg` post.
 - If a user shares their UTM'ed URL with other people, there could be duplicate referral codes but associated with different registrants:
   See a [screenshot](https://cl.ly/0v210N283y2X) of what this data looks like (note: the user depicted in this spreadsheet is fake.)
+
+# Email Subscriptions
+
+Admins can upload CSV's of Instapage leads to subscribe users to email newsletters. The import will create or update an existing user via the Northstar API.

--- a/resources/views/pages/failed-jobs/show.blade.php
+++ b/resources/views/pages/failed-jobs/show.blade.php
@@ -17,11 +17,9 @@
       <div class="col-sm-9">
         <strong>{{$data->commandName}}</strong>
         @isset($data->parameters)
-          <ul>
-            @foreach ($data->parameters as $key => $value)
-              <li><code>{{$key}}</code> {{$value}}</li>
-            @endforeach
-          </ul>
+          <code>
+            {{json_encode($data->parameters, TRUE)}}
+          </code>
         @endif
       </div>
     </div>


### PR DESCRIPTION
### What's this PR do?

This pull request encodes the failedJob parameters, when trying to view a permalink we get a `htmlspecialchars() expects parameter 1 to be string` error.

Also moves the RTV import docs into just imports/readme for easier reading on github

Also displays a post referrer_user_id in the result of the test import form for easier testing

### How should this be reviewed?

👀 

### Any background context you want to provide?

Looking to get more info on the failed jobs we seem to be getting since turning on the Update SMS feature, seemingly only when we're trying to pass a `stop` value for `sms_status`. Seeing the full exception on the failedJob permalink should hopefully uncover more details on why these requests are failing.

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
