### PR TITLE
Log exception messages

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -32,6 +32,8 @@ class Handler extends ExceptionHandler
      */
     public function report(Exception $exception)
     {
+        \Log::error(json_encode($exception->errors()));
+
         parent::report($exception);
     }
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -49,7 +49,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function handle()
     {
-        info('progress_log: Processing Rock The Vote record');
+        info('Processing Rock The Vote record', ['stared_registration' => $this->record->startedRegistration]);
 
         $user = $this->getUser($this->userData['id'], $this->userData['email'], $this->userData['mobile']);
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -49,11 +49,13 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function handle()
     {
-        info('Processing Rock The Vote record', ['stared_registration' => $this->record->startedRegistration]);
+        info('Processing Rock The Vote record', ['started_registration' => $this->record->startedRegistration]);
 
         $user = $this->getUser($this->userData['id'], $this->userData['email'], $this->userData['mobile']);
 
         if (! $user) {
+            info('User not found, creating user');
+
             $user = $this->createUser();
 
             $post = $this->createPost($user);

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -30,6 +30,8 @@ class RockTheVoteRecord
             $config = ImportType::getConfig(ImportType::$rockTheVote);
         }
 
+        $this->startedRegistration = $record['Started registration'];
+
         $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);
         $rtvStatus = $this->parseVoterRegistrationStatus($record['Status'], $record['Finish with State']);
 
@@ -82,8 +84,6 @@ class RockTheVoteRecord
      */
     public function parseReferralCode($referralCode)
     {
-        info('Parsing referral code: ' . $referralCode);
-
         $result = [
             'user_id' => null,
             'referrer_user_id' => null,


### PR DESCRIPTION
### What's this PR do?

This pull request logs the output of an exception's `messages()` function, which should hopefully shed some light on why we're seeing an uptick in validation errors after enabling the RTV import's Update User SMS feature on Monday, 5/11. It also logs the started registration date time upon processing a RTV record, to make it easier to pinpoint which records could be triggering the errors.

### How should this be reviewed?

I overwrote the `is_valid_mobile` helper to test trying to create an account with an invalid phone number. 

Logs on master:

```
[2020-05-15 05:47:16] local.INFO: Parsing referral code: source:test,source_details:ChompyUI  
[2020-05-15 05:47:16] local.INFO: progress_log: Processing Rock The Vote record  
```

Logs on this branch:
```
[2020-05-15 05:39:45] local.INFO: Processing Rock The Vote record {"started_registration":"2020-05-15 05:39:04 +0000"} 
[2020-05-15 05:39:46] local.INFO: User not found, creating user  
[2020-05-15 05:39:46] local.ERROR: {"mobile":["The mobile must be a valid US phone number."]} 
```

### Relevant tickets

References [Pivotal #172805635](https://www.pivotaltracker.com/story/show/172805635).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
