### PR TITLE
Check if errors method exists before sending to log

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -32,7 +32,9 @@ class Handler extends ExceptionHandler
      */
     public function report(Exception $exception)
     {
-        \Log::error(json_encode($exception->errors()));
+        $logMessage = method_exists($exception, 'errors') ? json_encode($exception->errors()) : $exception->getMessage();
+
+        \Log::error($logMessage);
 
         parent::report($exception);
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -49,6 +49,7 @@ function is_anonymous_mobile($mobile)
  */
 function is_valid_mobile($mobile)
 {
+    return true;
     // This phone number has been passed before and fails Northstar validation.
     if ($mobile == '000-000-0000') {
         return false;

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -49,7 +49,6 @@ function is_anonymous_mobile($mobile)
  */
 function is_valid_mobile($mobile)
 {
-    return true;
     // This phone number has been passed before and fails Northstar validation.
     if ($mobile == '000-000-0000') {
         return false;


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug introduced by #166 where sometimes we see:  `Uncaught Error: Call to undefined method Symfony\Component\Debug\Exception\FatalErrorException::errors()`

### How should this be reviewed?

👀 

### Any background context you want to provide?

🩹 

### Relevant tickets

References [Pivotal #172805635](https://www.pivotaltracker.com/story/show/172805635).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
