### PR TITLE
Removes startedRegistration property added in #166

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -49,7 +49,9 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function handle()
     {
-        info('Processing Rock The Vote record', ['started_registration' => $this->record->startedRegistration]);
+        $postDetails = $this->record->getPostDetails();
+
+        info('Processing Rock The Vote record', ['started_registration' => $postDetails['Started registration']]);
 
         $user = $this->getUser($this->userData['id'], $this->userData['email'], $this->userData['mobile']);
 

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -30,8 +30,6 @@ class RockTheVoteRecord
             $config = ImportType::getConfig(ImportType::$rockTheVote);
         }
 
-        $this->startedRegistration = $record['Started registration'];
-
         $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);
         $rtvStatus = $this->parseVoterRegistrationStatus($record['Status'], $record['Finish with State']);
 


### PR DESCRIPTION
### What's this PR do?

This pull request removes the convenience `startedRegistration` property added to a `RockTheVoteRecord` in #166 -- because older failed jobs in the queue don't have it set.

This results in the error:
```
 Undefined property: Chompy\RockTheVoteRecord::$startedRegistration   
```
when we retry these failed jobs.

Instead, we can use the record's `getPostDetails` helper to inspect the record's `Started registration` datetime.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🌵 

### Relevant tickets

References [Pivotal #172805635](https://www.pivotaltracker.com/story/show/172805635).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
