### PR TITLE
Remove RTV Update User SMS feature flag

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -265,7 +265,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
         if (self::shouldUpdateStatus($user->voter_registration_status, $this->userData['voter_registration_status'])) {
             $payload['voter_registration_status'] = $this->userData['voter_registration_status'];
         }
-  
+
         info('Checking for SMS subscription updates', ['user' => $user->id]);
 
         $payload = array_merge($payload, $this->getUserSmsSubscriptionUpdatePayload($user));

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -265,12 +265,10 @@ class ImportRockTheVoteRecord implements ShouldQueue
         if (self::shouldUpdateStatus($user->voter_registration_status, $this->userData['voter_registration_status'])) {
             $payload['voter_registration_status'] = $this->userData['voter_registration_status'];
         }
+  
+        info('Checking for SMS subscription updates', ['user' => $user->id]);
 
-        if (config('import.rock_the_vote.update_user_sms_enabled') == 'true') {
-            info('Checking for SMS subscription updates', ['user' => $user->id]);
-
-            $payload = array_merge($payload, $this->getUserSmsSubscriptionUpdatePayload($user));
-        }
+        $payload = array_merge($payload, $this->getUserSmsSubscriptionUpdatePayload($user));
 
         if (! count($payload)) {
             info('No changes to update for user', ['user' => $user->id]);

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "aws/aws-sdk-php": "~3.0",
         "dfurnes/environmentalist": "0.0.2",
         "doctrine/dbal": "^2.6",
-        "dosomething/gateway": "^1.17",
+        "dosomething/gateway": "3.0.0",
         "fideloper/proxy": "^4.0",
         "itsgoingd/clockwork": "^3.0",
         "laravel/framework": "5.7.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4960,6 +4960,7 @@
                     "email": "jakub.onderka@gmail.com"
                 }
             ],
+            "abandoned": "php-parallel-lint/php-console-color",
             "time": "2018-09-29T17:23:10+00:00"
         },
         {
@@ -5006,6 +5007,7 @@
                 }
             ],
             "description": "Highlight PHP code in terminal",
+            "abandoned": "php-parallel-lint/php-console-highlighter",
             "time": "2018-09-29T18:48:56+00:00"
         },
         {

--- a/config/import.php
+++ b/config/import.php
@@ -74,8 +74,6 @@ return [
             'register-form',
             'registration_complete',
         ],
-        // Whether to update SMS profile information for an existing user.
-        'update_user_sms_enabled' => env('ROCK_THE_VOTE_UPDATE_USER_SMS_ENABLED', 'false'),
         // Constants to use when creating a new user.
         'user' => [
             'email_subscription_topics' => env('ROCK_THE_VOTE_EMAIL_SUBSCRIPTION_TOPICS', 'community'),

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Third-parties with authorized access can post data to the Chompy API. See [API d
 
 Chompy supports imports of two types of CSV:
 
-- [Rock The Vote voter registrations](<(https://github.com/DoSomething/chompy/tree/master/docs/imports.md#rock-the-vote).>)
+- [Rock The Vote voter registrations](https://github.com/DoSomething/chompy/tree/master/docs/imports.md#rock-the-vote)
 
 - Email subscriptions to newsletters
 

--- a/resources/views/pages/partials/rock-the-vote/create.blade.php
+++ b/resources/views/pages/partials/rock-the-vote/create.blade.php
@@ -19,15 +19,6 @@
     </div>
 </div>
 <div class="form-group row">
-    <label class="col-sm-3 col-form-label">Update SMS subscriptions</label>
-    <div class="col-sm-9">
-        <p class="form-control-static">{{ $config['update_user_sms_enabled'] ? 'ON' : 'OFF'  }}</p>
-        <small class="form-text text-muted">
-          If this is ON, an existing user's SMS subscription will be updated per whether they opted-in to <a href="https://github.com/DoSomething/chompy/blob/master/docs/imports/rock-the-vote.md#mobile" target="_blank">receive texts from DS</a>.
-        </small>
-    </div>
-</div>
-<div class="form-group row">
     <label class="col-sm-3 col-form-label">User source detail</label>
     <div class="col-sm-9">
         <p class="form-control-static"><code>{{ $config['user']['source_detail'] }}</code></p>

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -12,13 +12,7 @@ use DoSomething\Gateway\Resources\NorthstarUser;
 
 class ImportRockTheVoteRecordTest extends TestCase
 {
-    /**
-     * Set or unset the Update User SMS Subscription feature flag.
-     */
-    private function enableUpdateUserSmsFeature(bool $shouldUpdate)
-    {
-        \Config::set('import.rock_the_vote.update_user_sms_enabled', $shouldUpdate ? 'true' : 'false');
-    }
+
 
     /**
      * Test that user and post are created if user not found.
@@ -135,13 +129,10 @@ class ImportRockTheVoteRecordTest extends TestCase
      */
     public function testUpdatesUserIfShouldChangeStatus()
     {
-        $this->enableUpdateUserSmsFeature(false);
-
         $userId = $this->faker->northstar_id;
         $startedRegistration = $this->faker->daysAgoInRockTheVoteFormat();
         $postId = $this->faker->randomDigitNotNull;
         $row = $this->faker->rockTheVoteReportRow([
-            'Phone' => $this->faker->phoneNumber,
             'Started registration' => $startedRegistration,
             'Status' => 'Complete',
             'Finish with State' => 'Yes',
@@ -163,10 +154,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         $this->rogueMock->shouldNotReceive('createPost');
         $this->northstarMock->shouldReceive('updateUser')->with($userId, [
-            /**
-             * Note: If the ROCK_THE_VOTE_UPDATE_USER_SMS_ENABLED config var is set to true, we'd
-             * additionally update the user mobile field here too.
-             */
             'voter_registration_status' => 'registration_complete',
         ])->andReturn(new NorthstarUser([
             'id' => $userId,
@@ -190,40 +177,6 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Test that user mobile is not updated when row has a phone, user does not have a mobile, and
-     * update_user_sms_enabled config is false.
-     *
-     * @return void
-     */
-    public function testSmsSubscriptionIsNotUpdatedIfUpdateUserSmsFeatureDisabled()
-    {
-        $this->enableUpdateUserSmsFeature(false);
-
-        $user = new NorthstarUser([
-            'id' => $this->faker->northstar_id,
-            'voter_registration_status' => 'step-1',
-            'sms_status' => null,
-        ]);
-        $phoneNumber = $this->faker->phoneNumber;
-        $row = $this->faker->rockTheVoteReportRow([
-            'Opt-in to Partner SMS/robocall' => 'Yes',
-            'Phone' =>  $phoneNumber,
-            'Status' => 'Step 2',
-        ]);
-        $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
-
-        // If our feature flag was enabled, we'd additionally update mobile, sms status & topics.
-        $this->northstarMock->shouldReceive('updateUser')->with($user->id, [
-            'voter_registration_status' => 'step-2',
-        ])->andReturn(new NorthstarUser([
-            'id' => $user->id,
-            'voter_registration_status' => 'step-2',
-        ]));
-
-        $job->updateUserIfChanged($user);
-    }
-
-    /**
      * Test that user mobile is updated when row has a phone, user does not have a mobile, and
      * update_user_sms_enabled config is true.
      *
@@ -231,8 +184,6 @@ class ImportRockTheVoteRecordTest extends TestCase
      */
     public function testUserUpdatePayloadContainsMobileIfProvided()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $user = new NorthstarUser([
             'id' => $this->faker->northstar_id,
             'voter_registration_status' => 'step-1',
@@ -563,10 +514,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasNullSmsStatusAndOptsIn()
+    public function testUpdateUserSmsWhenUserHasNullSmsStatusAndOptsIn()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(null, true);
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -584,10 +533,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasNullSmsStatusAndOptsOut()
+    public function testUpdateUserSmsWhenUserHasNullSmsStatusAndOptsOut()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(null, false);
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -604,10 +551,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasActiveSmsStatusAndOptsIn()
+    public function testUpdateUserSmsWhenUserHasActiveSmsStatusAndOptsIn()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$active, true);
 
         // Nothing to update, user already has 'voting' topic.
@@ -621,10 +566,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasActiveSmsStatusAndOptsOut()
+    public function testUpdateUserSmsWhenUserHasActiveSmsStatusAndOptsOut()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$active, false);
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -642,10 +585,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasLessSmsStatusAndOptsIn()
+    public function testUpdateUserSmsWhenUserHasLessSmsStatusAndOptsIn()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$less, true);
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -663,10 +604,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasLessSmsStatusAndOptsOut()
+    public function testUpdateUserSmsWhenUserHasLessSmsStatusAndOptsOut()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$less, false);
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -684,10 +623,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasPendingSmsStatusAndOptsIn()
+    public function testUpdateUserSmsWhenUserHasPendingSmsStatusAndOptsIn()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$pending, true);
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -705,10 +642,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasPendingSmsStatusAndOptsOut()
+    public function testUpdateUserSmsWhenUserHasPendingSmsStatusAndOptsOut()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$pending, false);
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -726,10 +661,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasStopSmsStatusAndOptsIn()
+    public function testUpdateUserSmsWhenUserHasStopSmsStatusAndOptsIn()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$stop, true);
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -747,10 +680,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasStopSmsStatusAndOptsOut()
+    public function testUpdateUserSmsWhenUserHasStopSmsStatusAndOptsOut()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$stop, false);
 
         $this->northstarMock->shouldNotReceive('updateUser');
@@ -763,10 +694,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasUndeliverableSmsStatusAndOptsIn()
+    public function testUpdateUserSmsWhenUserHasUndeliverableSmsStatusAndOptsIn()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$undeliverable, true);
 
         $this->northstarMock->shouldReceive('updateUser')
@@ -784,10 +713,8 @@ class ImportRockTheVoteRecordTest extends TestCase
     /**
      * @return void
      */
-    public function testEnabledUpdateUserSmsWhenUserHasUndeliverableSmsStatusAndOptsOut()
+    public function testUpdateUserSmsWhenUserHasUndeliverableSmsStatusAndOptsOut()
     {
-        $this->enableUpdateUserSmsFeature(true);
-
         $mocks = $this->getMocksForUpdateUserSmsTest(SmsStatus::$undeliverable, false);
 
         $this->northstarMock->shouldReceive('updateUser')

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -12,8 +12,6 @@ use DoSomething\Gateway\Resources\NorthstarUser;
 
 class ImportRockTheVoteRecordTest extends TestCase
 {
-
-
     /**
      * Test that user and post are created if user not found.
      *


### PR DESCRIPTION
### What's this PR do?

This pull request removes the check for the `update_user_sms_enabled` config as well as the config itself, since this feature has been turned on. 

This helps to simplify the import and test coverage, as a predecessor for additional import modifications we need to make in a future PR.

This PR branches off #169 and will need to be edited to merge into `master` once #169 is approved.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🐸 

### Relevant tickets

References [Pivotal #172805635](https://www.pivotaltracker.com/story/show/172805635.

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
