### PR TITLE
Fixes mobile already taken bug in RTV import

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -87,10 +87,10 @@ class ImportRockTheVoteRecord implements ShouldQueue
             ];
         }
 
-        $user = $this->updateVoterRegistrationStatusIfChanged($user);
+        $user = $this->updateUserVoterRegistrationStatusIfChanged($user);
 
         if ($this->userData['mobile']) {
-            $user = $this->updateSmsSubscriptionIfChanged($user);
+            $user = $this->updateUserSmsSubscriptionIfChanged($user);
         }
 
         if ($post = $this->getPost($user)) {
@@ -295,7 +295,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
      *
      * @return NorthstarUser
      */
-    public function updateVoterRegistrationStatusIfChanged(NorthstarUser $user)
+    public function updateUserVoterRegistrationStatusIfChanged(NorthstarUser $user)
     {
         info('Checking for voter registration status update', ['user' => $user->id]);
 
@@ -315,7 +315,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
      *
      * @return NorthstarUser
      */
-    public function updateSmsSubscriptionIfChanged(NorthstarUser $user)
+    public function updateUserSmsSubscriptionIfChanged(NorthstarUser $user)
     {
         info('Checking for SMS subscription update', ['user' => $user->id]);
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -308,14 +308,14 @@ class ImportRockTheVoteRecord implements ShouldQueue
     {
         info('Checking for SMS subscription update', ['user' => $user->id]);
 
-        // We don't need to update user's SMS subscription if we already did for this registration.
+        // Don't update import user's SMS subscription if we already did for this registration.
         if (RockTheVoteLog::hasAlreadyUpdatedSmsSubscription($this->record, $user)) {
             info('Already updated SMS subscription for this registration', ['user' => $user->id]);
 
             return $user;
         }
 
-        // If the user already has a mobile, we don't want to change it - just update subscription.
+        // If import user already has a mobile, don't change it - just update subscription.
         if ($user->mobile) {
             return $this->updateUser($user, $this->getUserSmsSubscriptionUpdatePayload($user));
         }

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -191,8 +191,9 @@ class ImportRockTheVoteRecord implements ShouldQueue
      * @param array $data
      * @return NorthstarUser
      */
-    private function updateUser($user, $data) {
-        if (!$data) {
+    private function updateUser($user, $data)
+    {
+        if (! $data) {
             info('No updates to make', ['user' => $user->id]);
 
             return $user;
@@ -303,7 +304,8 @@ class ImportRockTheVoteRecord implements ShouldQueue
      *
      * @return NorthstarUser
      */
-    public function updateSmsSubscriptionIfChanged(NorthstarUser $user) {
+    public function updateSmsSubscriptionIfChanged(NorthstarUser $user)
+    {
         info('Checking for SMS subscription update', ['user' => $user->id]);
 
         // We don't need to update user's SMS subscription if we already did for this registration.

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -89,6 +89,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
         $user = $this->updateUserVoterRegistrationStatusIfChanged($user);
 
+        // If registration does not have a mobile provided, no need to update SMS subscription.
         if ($this->userData['mobile']) {
             $user = $this->updateUserSmsSubscriptionIfChanged($user);
         }

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -207,7 +207,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($user);
+        $job->updateUserSmsSubscriptionIfChanged($user);
     }
 
     /**
@@ -433,7 +433,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $result = $job->updateSmsSubscriptionIfChanged($user);
+        $result = $job->updateUserSmsSubscriptionIfChanged($user);
     }
 
     /**
@@ -462,7 +462,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             ->andReturn($user);
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $result = $job->updateSmsSubscriptionIfChanged($user);
+        $result = $job->updateUserSmsSubscriptionIfChanged($user);
     }
 
     /**
@@ -532,7 +532,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -550,7 +550,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -565,7 +565,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -584,7 +584,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -603,7 +603,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -622,7 +622,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -641,7 +641,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -660,7 +660,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -679,7 +679,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -693,7 +693,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -712,7 +712,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -730,7 +730,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateSmsSubscriptionIfChanged($mocks->user);
+        $job->updateUserSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -433,11 +433,11 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
-        $result = $job->updateUserSmsSubscriptionIfChanged($user);
+        $job->updateUserSmsSubscriptionIfChanged($user);
     }
 
     /**
-     * Test we update the import user's mobile if they don't have one set, and no other user owns
+     * Test that import user's mobile is updated if they don't have one set, and no other user owns
      * the mobile number.
      *
      * @return void
@@ -453,7 +453,6 @@ class ImportRockTheVoteRecordTest extends TestCase
         ]);
         // If the mobile is not owned by any other users, we can update our import user with it.
         $this->northstarMock->shouldReceive('getUser')->andReturn(null);
-        // Test that we update our import user witht he mobile number.
         $this->northstarMock->shouldReceive('updateUser')
             ->with($user->id, [
                 'mobile' => $phoneNumber,
@@ -467,11 +466,12 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Test we update the user that owns the mobile if another user owns the import mobile.
+     * Test the owner of the mobile is updated if import user does not have a mobile set, but the
+     * import mobile is taken by another user.
      *
      * @return void
      */
-    public function testMobileOwnerSubscriptionIsUpdatedIfImportUserHasNoMobileAndMobileIsTaken()
+    public function testMobileOwnerIsUpdatedIfImportUserHasNoMobileAndMobileIsTaken()
     {
         $phoneNumber = $this->faker->phoneNumber;
         $user = new NorthstarUser([
@@ -484,11 +484,9 @@ class ImportRockTheVoteRecordTest extends TestCase
         $row = $this->faker->rockTheVoteReportRow([
             'Phone' => $phoneNumber,
         ]);
-        // If the mobile is not owned by any other users, we can update our import user with it.
         $this->northstarMock->shouldReceive('getUser')
             ->with('mobile', $phoneNumber)
             ->andReturn($mobileUser);
-        // Test that we update the mobile user's SMS subscrition.
         $this->northstarMock->shouldReceive('updateUser')
             ->with($mobileUser->id, [
                 'sms_status' => SmsStatus::$stop,
@@ -501,7 +499,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Test that we do not update an existing user's mobile if one already exists.
+     * Test that an existing user's mobile is not updated if a value already exists.
      *
      * @return void
      */
@@ -521,7 +519,7 @@ class ImportRockTheVoteRecordTest extends TestCase
          * a mobile.
          */
         $this->northstarMock->shouldNotReceive('getUser');
-        // Expect that we do update subscription info, but not their mobile.
+        // Verify that subscription fields are updated, but mobile is not.
         $this->northstarMock->shouldReceive('updateUser')
             ->with($user->id, [
                 'sms_status' => SmsStatus::$active,

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -207,7 +207,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             'voter_registration_status' => 'step-2',
         ]));
 
-        $job->updateUserIfChanged($user);
+        $job->updateSmsSubscriptionIfChanged($user);
     }
 
     /**
@@ -525,7 +525,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -543,7 +543,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -558,7 +558,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -577,7 +577,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -596,7 +596,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -615,7 +615,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -634,7 +634,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -653,7 +653,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -672,7 +672,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -686,7 +686,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -705,7 +705,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**
@@ -723,7 +723,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $job = new ImportRockTheVoteRecord($mocks->row, factory(ImportFile::class)->create());
 
-        $job->updateUserIfChanged($mocks->user);
+        $job->updateSmsSubscriptionIfChanged($mocks->user);
     }
 
     /**

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -451,12 +451,15 @@ class ImportRockTheVoteRecordTest extends TestCase
         $row = $this->faker->rockTheVoteReportRow([
             'Phone' => $phoneNumber,
         ]);
+        $this->northstarMock
+          ->shouldReceive('getUser')
+          ->andReturn(null);
         $this->northstarMock->shouldReceive('updateUser')
             ->with($user->id, [
                 'mobile' => $phoneNumber,
-                'sms_status' => SmsStatus::$stop
+                'sms_status' => SmsStatus::$stop,
             ])
-            ->andReturn($mocks->user);
+            ->andReturn($user);
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());
 
         $result = $job->updateSmsSubscriptionIfChanged($user);


### PR DESCRIPTION
### What's this PR do?

This pull request fixes bug that occurs when the import tries to add a provided mobile for an existing user, but the mobile is taken by another user.

This PR avoids the error by making a `GET /users` request to Northstar to check if another user owns the mobile before we add it. If they do, we update the SMS status and topics of the owner of the mobile user. 

To handle this, I split out the `updateUserIfChanged` into `updateUserVoterRegistrationStatusIfChanged` and `updateUserSmsSubscriptionStatusIfChanged` functions. It does mean we may end up making 2 update requests for a single user -- but I think the code would get more complicated to try to handle it via 1. It's already a big PR as is, so I felt this was a good approach (also was suggested by @DFurnes over in the [doc of potential solutions](https://docs.google.com/document/d/1Mcu9tbrx3s5qnTZOYqdVx4PvRAtnGAN6ZCM-2DYo1VA/edit?usp=sharing) I put together in figuring out how to resolve)

### How should this be reviewed?

👀 
I'll be putting together some QA instructions once this gets merged to test via the import form. Also added the `mobile_user` to the results of the import form submit (and as an aside -- also clearer messaging for when an import is skipped because the row has already been imported)

### Any background context you want to provide?

Q: You're setting a `$this->mobileUser` property on the `ImportRockTheVoteRecord` job. Shouldn't we also have a `$this->user` to keep consistent?

A: It would be nice to keep this consistent, but looking to avoid any changes we *don't* need to make for the sake of this bug - to help keep these changes reviewiable. If we went this route, it'd make sense to also create a `$this->post` vs passing around the `$post` but we can save for a rainy day.

Q: Can you update the docs?

A: Yes - will do this in a separate PR again, to cut down on number of changes to review.

### Relevant tickets

References [Pivotal #172805635](https://www.pivotaltracker.com/story/show/172805635).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
