### PR TITLE
Cleanup from mobile-already-taken bug fix

### DIFF
--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -97,7 +97,7 @@ So the full hierarchy order taken into account when updating the profile from lo
 
 If an existing user has a null `mobile` profile field and provides a phone number via RTV form, the import will save it to the user's `mobile` profile field if we cannot find an existing user for the mobile.
 
-If the mobile provided is already taken by another user, the import will update the SMS subscription of the user that owns the mobile number. per the SMS opt-in import value.
+If the mobile provided is already taken by another user, the import will update the SMS subscription of the user that owns the mobile number.
 
 **Notes**:
 

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -95,12 +95,15 @@ So the full hierarchy order taken into account when updating the profile from lo
 
 ### Mobile
 
-If an existing user has a null `mobile` profile field and provides a phone number via RTV form, we save it to the user's `mobile` profile field.
+If an existing user has a null `mobile` profile field and provides a phone number via RTV form, the import will save it to the user's `mobile` profile field if we cannot find an existing user for the mobile.
+
+If the mobile provided is already taken by another user, the import will update the SMS subscription of the user that owns the mobile number. per the SMS opt-in import value.
 
 **Notes**:
 
-- We do **not** override an existing phone number.
-- We save a user's mobile number regardless of whether they opt-in to SMS messaging from DS.
+- We will **not** override an existing phone number on a user if they provide a different one in the RTV form.
+
+- If provided in the RTV form, we save a user's mobile number (new or existing) regardless of whether they opt-in to SMS messaging from DS.
 
 ### Email Subscription
 


### PR DESCRIPTION
### What's this PR do?

Cleanup from #172: 

* Documents check for whether a mobile is taken, and clarifies we won't update an existing number if a different one has been found

*  Updates a stale test that was throwing an undefined index error -- `getUserSmsSubscriptionUpdatePayload` was refactored in #172 to only be used when an import row has a mobile (moving the check into `handle` instead of `updateUserIfChanged`)

### How should this be reviewed?

👀 

### Any background context you want to provide?

I'm realizing the "Online Drives" section of the docs need a major overhaul per our new OVRD pages, which I plan to tackle in tandem with updating the Voter Registration tracking source docs mentioned over in https://github.com/DoSomething/phoenix-next/pull/2164#discussion_r428714489

### Relevant tickets

References [Pivotal #172805635](https://www.pivotaltracker.com/story/show/172805635).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
