### PR TITLE
Updates RTV docs

### DIFF
--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -163,15 +163,11 @@ If the `Tracking Source` doesn't contain a NS ID, the import searches for an exi
 
 - Data extracts the `source` and `source_detail` values found in the `Tracking Source` into Looker for voter registration reporting.
 
-- The `submission_created_at` date is when the importer ran. Details about when the registration was created/updated are in the `source_details`.
+- Very early iterations of this import would:
 
-- All of these signups will have a `source` of `importer-client` (this is how messaging is suppressed in C.io)
+  - Save the action per the month that the registration came in (e.g. `february-2018-rockthevote`)
 
-- In early iterations of the import, the month that the registration came in would inform the `action` column (e.g., february-2018-rockthevote)
-
-- In early iterations of the import, we would pass Campaign/Run IDs as parameters within the referral code to use when upsert a `voter-reg` post.
-
-- If a user shares their UTM'ed URL with other people, there could be duplicate referral codes but associated with different registrants. See a [screenshot](https://cl.ly/0v210N283y2X) of what this data looks like (note: the user depicted in this spreadsheet is fake.)
+  - Use Campaign/Run IDs key/values within the Tracking Source to use when upserting a `voter-reg` post
 
 - Before we partnered with Rock The Vote on voter registration, we had partnered with TurboVote in 2016, 2018. See [VR Tech Inventory](https://docs.google.com/document/d/1xs2C3DNdD5h1j_abBrGVBNrsrxKvwn2VHDWweIEhvqc/edit?usp=sharing) for more details.
 

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -48,15 +48,13 @@ These definitions can be found in the [RTV docs](https://www.rockthevote.org/pro
 
 ### Historical values
 
-- We used to save all of the `step-*` status values as `uncertain`, up until [April 2020](https://github.com/DoSomething/chompy/pull/153).
-
-- We used to save `rejected` and `under-18` values as `ineligible`.
+- We used to save all of the `step-*` status values as `uncertain`, and the `rejected` and `under-18` values as `ineligible`, up until [April 2020](https://github.com/DoSomething/chompy/pull/153).
 
 - The TurboVote data (which we imported before Rock The Vote - see [Notes](#notes)), would supply a `confirmed` status - similar to the Rock the Vote `Completed` status.
 
 ### Status Hierarchy
 
-Because RTV CSVs may contain multiple records _for a single user_, we use the following hierarchy, from lowest to highest, to determine which status should be reported on their Rogue post if a user post already exists for the import Action and its `Started registration` datetime:
+Because RTV CSVs may contain multiple records _for a single user_, we use the following hierarchy, from lowest to highest, to determine which status should be reported on their `voter-reg` post if a post already exists for user, import action, and its `Started registration` datetime:
 
 - `uncertain`
 - `ineligible`

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -159,15 +159,15 @@ If the `Tracking Source` doesn't contain a NS ID, the import searches for an exi
 
   - Example: At 12pm, the import finds Alice at status `step-2` and opting to SMS. Alice is sent a welcome text, and unsubscribes. The import runs again at 1pm, and finds Alice at a completed status, but still having opted in from earlier. Alice has already unsubscribed at this point, we would not want the import to resubscribe her per the opt-in from the previous hour.
 
-- Prior to [changes made in April 2020](https://github.com/DoSomething/chompy/pull/154), the import would upsert a single post for all registrations for an action ID (e.g registering to vote twice in 2018 resulted in a single `voter-reg` post).
+- Prior to [changes made in April 2020](https://github.com/DoSomething/chompy/pull/154), the import would upsert a single post for all registrations for an action ID (e.g registering to vote three times in 2018 resulted in a single post, not three).
 
 - Data extracts the `source` and `source_detail` values found in the `Tracking Source` into Looker for voter registration reporting.
 
 - Very early iterations of this import would:
 
-  - Save the action per the month that the registration came in (e.g. `february-2018-rockthevote`)
+  - Save the post action based on the month that the registration came in (e.g. `february-2018-rockthevote`)
 
-  - Use Campaign/Run IDs key/values within the Tracking Source to use when upserting a `voter-reg` post
+  - Use Campaign/Run IDs key/values within the Tracking Source to use when upserting the post
 
 - Before we partnered with Rock The Vote on voter registration, we had partnered with TurboVote in 2016, 2018. See [VR Tech Inventory](https://docs.google.com/document/d/1xs2C3DNdD5h1j_abBrGVBNrsrxKvwn2VHDWweIEhvqc/edit?usp=sharing) for more details.
 

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -1,14 +1,12 @@
 # Rock The Vote
 
-We import CSVs from Rock The Vote (RTV) to upsert users and their `voter-reg` posts. We previously imported this data from TurboVote (TV) in 2016, 2018. See [VR Tech Inventory](https://docs.google.com/document/d/1xs2C3DNdD5h1j_abBrGVBNrsrxKvwn2VHDWweIEhvqc/edit?usp=sharing) for more details.
+Chompy integrates with the Rock The Vote (RTV) API to generate, download, and import voter registration CSV's on an hourly basis.
 
 ## Overview
 
-Chompy integrates with the RTV API to generate, download, and import voter registration CSV's on an hourly basis.
-
 The import upserts a `voter-reg` type post for each unique "Started registration" datetime we receive for a user -- saving it to an action we set via config variable. This import action is changed each election year, in order to track user registrations per election.
 
-If a user registers to vote twice in 2020 (e.g. change of address), two `voter-reg` posts will be upserted for the user and this year's action. Prior to [changes made in April 2020](https://github.com/DoSomething/chompy/pull/154), the import would upsert a single post for all registrations for an action ID (e.g registering to vote twice in 2018 resulted in a single `voter-reg` post).
+If a user registers to vote twice in 2020 (e.g. change of address), two `voter-reg` posts will be upserted for the user and this year's action.
 
 ## Tracking Source
 
@@ -54,7 +52,7 @@ These definitions can be found in the [RTV docs](https://www.rockthevote.org/pro
 
 - We used to save `rejected` and `under-18` values as `ineligible`.
 
-- The TurboVote data (which we imported before Rock The Vote), would supply a `confirmed` status - similar to the Rock the Vote `Completed` status.
+- The TurboVote data (which we imported before Rock The Vote - see [Notes](#notes)), would supply a `confirmed` status - similar to the Rock the Vote `Completed` status.
 
 ### Status Hierarchy
 
@@ -72,7 +70,7 @@ Because RTV CSVs may contain multiple records _for a single user_, we use the fo
 - `register-OVR`
 - `register-form`
 
-For example: If a user has a `confirmed` status already from a previous TurboVote import, and the RTV file suggests that it should be `step-1`, do not update.
+For example: If a user has a `confirmed` status already from a previous TurboVote import (see [Notes](#notes), and the RTV file suggests that it should be `step-1`, do not update.
 
 We’ve established this hierarchy because each time a user interacts with the RTV form, a new row is created in the CSV. There are the edge cases when a user is chased to finish their registration that they would be interacting with the same row (thus the "steps"). Here’s one example:
 
@@ -91,7 +89,7 @@ If there's an existing status on the user, we follow the same hierarchy rules es
 
 - `unregistered` -- can be set when creating an account on the web, denoting that the user has not registered to vote.
 
-- `registration_complete` -- set from our RTV import if the record's status is either `register-form` or `register-ovr`.
+- `registration_complete` -- set from our RTV import if the record's status is either `register-form` or `register-OVR`.
 
 So the full hierarchy order taken into account when updating the profile from lowest to highest is:
 
@@ -161,6 +159,8 @@ If the `Tracking Source` doesn't contain a NS ID, the import searches for an exi
 
   - Example: At 12pm, the import finds Alice at status `step-2` and opting to SMS. Alice is sent a welcome text, and unsubscribes. The import runs again at 1pm, and finds Alice at a completed status, but still having opted in from earlier. Alice has already unsubscribed at this point, we would not want the import to resubscribe her per the opt-in from the previous hour.
 
+- Prior to [changes made in April 2020](https://github.com/DoSomething/chompy/pull/154), the import would upsert a single post for all registrations for an action ID (e.g registering to vote twice in 2018 resulted in a single `voter-reg` post).
+
 - Data extracts the `source` and `source_detail` values found in the `Tracking Source` into Looker for voter registration reporting.
 
 - The `submission_created_at` date is when the importer ran. Details about when the registration was created/updated are in the `source_details`.
@@ -172,6 +172,8 @@ If the `Tracking Source` doesn't contain a NS ID, the import searches for an exi
 - In early iterations of the import, we would pass Campaign/Run IDs as parameters within the referral code to use when upsert a `voter-reg` post.
 
 - If a user shares their UTM'ed URL with other people, there could be duplicate referral codes but associated with different registrants. See a [screenshot](https://cl.ly/0v210N283y2X) of what this data looks like (note: the user depicted in this spreadsheet is fake.)
+
+- Before we partnered with Rock The Vote on voter registration, we had partnered with TurboVote in 2016, 2018. See [VR Tech Inventory](https://docs.google.com/document/d/1xs2C3DNdD5h1j_abBrGVBNrsrxKvwn2VHDWweIEhvqc/edit?usp=sharing) for more details.
 
 # Email Subscriptions
 

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -12,13 +12,13 @@ If a user registers to vote twice in 2020 (e.g. change of address), two `voter-r
 
 ## Tracking Source
 
-Each registration may contain a `Tracking Source` column, which corresponds to the `source` query parameter we include when directing users to our Rock The Vote registration partner site.
+Each registration may contain a `Tracking Source` column, which corresponds to the `source` query parameter we include when directing users to our Rock The Vote registration partner site. See [Phoenix docs](https://app.gitbook.com/@dosomething/s/phoenix-documentation/development/features/voter-registration#tracking-source)
 
 The import saves the raw `Tracking Source` value property into the serialized `details` field of the `voter-reg` post it creates.
 
-It also inspects the value to see whether `referral` and `user` keys have been passed. You can find [details on the format in the Phoenix docs](https://app.gitbook.com/@dosomething/s/phoenix-documentation/development/features/voter-registration#tracking-source)
+It also inspects the value to see whether `referral` and `user` keys have been passed:
 
-- If a `referral` key exists, the `user` value should be saved as the `referrer_user_id` on the post (and user, if creating a new user).
+- If a `referral` key exists, the `user` value should be saved as the `referrer_user_id` on the post (and user, if creating a new user). This `referral` is set when a [beta is registering to vote via an alpha's OVRD page](https://app.gitbook.com/@dosomething/s/phoenix-documentation/development/features/voter-registration#online-drives).
 
 - If a `referral` key does not exist, the `user` value corresponds to the ID of the user that is registering to vote. If present, we use this first when checking to match a user to the given row we are importing.
 


### PR DESCRIPTION
### What's this PR do?

This pull request removes the "Online Drives" section that's now stale since we've launched OVRD v2 on Phoenix, and links out to the relevant docs per https://github.com/DoSomething/phoenix-next/pull/2169.

It also adds missing info about:

*  Only updating a user's SMS subscriptions once per unique registration, and provides an example of why that logic is necessary
. 
* Automated hourly imports via RTV API

And moves some of the historical context into notes, to hopefully improve the readability of the most pertinent info.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🕊️ 

### Relevant tickets

References [Pivotal #214616261](https://www.pivotaltracker.com/story/show/172805635/comments/214616261).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.