### PR TITLE
Add post.group_id if found in tracking source

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -115,7 +115,15 @@ class ImportRockTheVoteRecord implements ShouldQueue
         $result = [
             'user' => [],
             'mobile_user' => [],
-            'post' => Arr::only($post, ['id', 'type', 'action_id', 'status', 'details', 'referrer_user_id']),
+            'post' => Arr::only($post, [
+                'id',
+                'type',
+                'action_id',
+                'status',
+                'details',
+                'referrer_user_id',
+                'group_id',
+            ]),
         ];
 
         $userFields = ['id', 'email', 'mobile', 'voter_registration_status', 'sms_status', 'sms_subscription_topics', 'email_subscription_status', 'email_subscription_topics', 'referrer_user_id'];

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -76,7 +76,7 @@ class RockTheVoteRecord
 
     /**
      * Parses User ID or Referrer User ID from input value.
-     * Editors manually enter this value as a URL query string, so we safety check for typos.
+     * Editors may manually enter this value as a URL query string, so we safety check for typos.
      *
      * @param string $trackingSource
      * @return array
@@ -89,7 +89,8 @@ class RockTheVoteRecord
             'user_id' => null,
         ];
 
-        // Remove some nonsense that comes in front of the referral code sometimes
+        // Our voting portal sometimes includes this leading iframe value, we may not need this.
+        // @see https://dosomething.slack.com/archives/C1KL1MKAS/p1585091476054100
         if (str_contains($trackingSource, 'iframe?r=')) {
             $trackingSource = str_replace('iframe?r=', null, $trackingSource);
         }

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -70,6 +70,7 @@ class RockTheVoteRecord
 
         $this->userData['id'] = $trackingSource['user_id'];
         $this->userData['referrer_user_id'] = $trackingSource['referrer_user_id'];
+        $this->postData['group_id'] = $trackingSource['group_id'];
         $this->postData['referrer_user_id'] = $trackingSource['referrer_user_id'];
     }
 
@@ -83,8 +84,9 @@ class RockTheVoteRecord
     public function parseTrackingSource($trackingSource)
     {
         $result = [
-            'user_id' => null,
+            'group_id' => null,
             'referrer_user_id' => null,
+            'user_id' => null,
         ];
 
         // Remove some nonsense that comes in front of the referral code sometimes
@@ -114,15 +116,15 @@ class RockTheVoteRecord
             // Expected key: "user"
             if ($key === 'user' || $key === 'user_id' || $key === 'userid') {
                 $userId = $value[1];
-            }
-
+            } elseif ($key === 'group_id') {
+                $result['group_id'] = (int) $value[1];
             /**
              * If referral parameter is set to true, the user parameter belongs to the referring
              * user, not the user that should be associated with this voter registration record.
              *
              * Expected key: "referral"
              */
-            if (($key === 'referral' || $key === 'refferal') && str_to_boolean($value[1])) {
+            } elseif (($key === 'referral' || $key === 'refferal') && str_to_boolean($value[1])) {
                 /**
                  * Return result to force querying for existing user via this record email or mobile
                  * upon import.

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -66,21 +66,21 @@ class RockTheVoteRecord
             'action_id' => $config['post']['action_id'],
         ];
 
-        $referralCode = $this->parseReferralCode($record['Tracking Source']);
+        $trackingSource = $this->parseTrackingSource($record['Tracking Source']);
 
-        $this->userData['id'] = $referralCode['user_id'];
-        $this->userData['referrer_user_id'] = $referralCode['referrer_user_id'];
-        $this->postData['referrer_user_id'] = $referralCode['referrer_user_id'];
+        $this->userData['id'] = $trackingSource['user_id'];
+        $this->userData['referrer_user_id'] = $trackingSource['referrer_user_id'];
+        $this->postData['referrer_user_id'] = $trackingSource['referrer_user_id'];
     }
 
     /**
      * Parses User ID or Referrer User ID from input value.
      * Editors manually enter this value as a URL query string, so we safety check for typos.
      *
-     * @param string $referralCode
+     * @param string $trackingSource
      * @return array
      */
-    public function parseReferralCode($referralCode)
+    public function parseTrackingSource($trackingSource)
     {
         $result = [
             'user_id' => null,
@@ -88,20 +88,20 @@ class RockTheVoteRecord
         ];
 
         // Remove some nonsense that comes in front of the referral code sometimes
-        if (str_contains($referralCode, 'iframe?r=')) {
-            $referralCode = str_replace('iframe?r=', null, $referralCode);
+        if (str_contains($trackingSource, 'iframe?r=')) {
+            $trackingSource = str_replace('iframe?r=', null, $trackingSource);
         }
-        if (str_contains($referralCode, 'iframe?')) {
-            $referralCode = str_replace('iframe?', null, $referralCode);
+        if (str_contains($trackingSource, 'iframe?')) {
+            $trackingSource = str_replace('iframe?', null, $trackingSource);
         }
 
-        if (empty($referralCode)) {
+        if (empty($trackingSource)) {
             return $result;
         }
 
-        $referralCode = explode(',', $referralCode);
+        $trackingSource = explode(',', $trackingSource);
 
-        foreach ($referralCode as $value) {
+        foreach ($trackingSource as $value) {
             // See if we are dealing with ":" or "="
             if (str_contains($value, ':')) {
                 $value = explode(':', $value);

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -138,7 +138,7 @@ class RockTheVoteRecordTest extends TestCase
      */
     public function testSetsUserIdToNullIfNotExistsInTrackingSource()
     {
-        $trackingSource = 'campaignID:8017,campaignRunID:8022,source:email,source_details:newsletter_bdaytrigger';
+        $trackingSource = 'source:email,source_details:newsletter_bdaytrigger';
 
         $record = new RockTheVoteRecord($this->faker->rockTheVoteReportRow([
             'Tracking Source' => $trackingSource,
@@ -146,6 +146,26 @@ class RockTheVoteRecordTest extends TestCase
 
         $this->assertEquals($record->userData['id'], null);
         $this->assertEquals($record->userData['referrer_user_id'], null);
+        $this->assertEquals($record->postData['group_id'], null);
+        $this->assertEquals($record->postData['referrer_user_id'], null);
+    }
+
+    /**
+     * Test that a post group ID is set if found in tracking source .
+     *
+     * @return void
+     */
+    public function testSetsPostGroupIdIfExistsInTrackingSource()
+    {
+        $trackingSource = 'source:email,source_details:newsletter_bdaytrigger,group_id=12';
+
+        $record = new RockTheVoteRecord($this->faker->rockTheVoteReportRow([
+            'Tracking Source' => $trackingSource,
+        ]));
+
+        $this->assertEquals($record->userData['id'], null);
+        $this->assertEquals($record->userData['referrer_user_id'], null);
+        $this->assertEquals($record->postData['group_id'], 12);
         $this->assertEquals($record->postData['referrer_user_id'], null);
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the RTV import to include a `group_id` value when creating a `voter-reg` post if one is found within the tracking source.

It also renames the instances of "referral code" within the import code as "tracking source" to keep the name consistent with RTV terminology / internal [docs](https://dosomething.gitbook.io/phoenix-documentation/development/features/voter-registration#tracking-source), and hopefully make the code more readable. 

### How should this be reviewed?

👀 

An easy manual test is to use the test import form to create a new voter-reg post with a tracking source for a valid group ID, e.g `source:web,source_details:groupTest,group_id=3`.

Confirm the post is created with the expected `group_id` value.

### Any background context you want to provide?

We're not sending along the `group_id` from the web yet, but this gets us ready to store it properly once we are.

### Relevant tickets

References [Pivotal #173019785](https://www.pivotaltracker.com/story/show/173019785).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
