### PR TITLE
Fix two small bugs on the test form.

### DIFF
--- a/app/Http/Controllers/Web/ImportFileController.php
+++ b/app/Http/Controllers/Web/ImportFileController.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Request;
 use Chompy\Models\ImportFile;
 use Chompy\Models\RockTheVoteLog;
 use Chompy\Jobs\ImportFileRecords;
-use Illuminate\Support\Facades\Input;
 use Chompy\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Storage;
 use Chompy\Jobs\ImportRockTheVoteRecord;
@@ -185,7 +184,7 @@ class ImportFileController extends Controller
         }
 
         return redirect('import/'.$importType.'?source=test')
-            ->withInput(Input::all())
+            ->withInput($request->input())
             ->with('status', $result);
     }
 }

--- a/resources/views/pages/partials/rock-the-vote/test.blade.php
+++ b/resources/views/pages/partials/rock-the-vote/test.blade.php
@@ -16,7 +16,7 @@
   </div>
   <label for="addr_street2" class="col-sm-3 col-form-label">Home unit</label>
   <div class="col-sm-3">
-    {!! Form::text('addr_street1', $data['addr_street1'], ['class' => 'form-control']) !!}
+    {!! Form::text('addr_street2', $data['addr_street2'], ['class' => 'form-control']) !!}
   </div>
 </div>
 <div class="form-group row">


### PR DESCRIPTION
### What's this PR do?

This pull request fixes two small bugs on the "import test" form:

2️⃣ Fixes the "Home unit" field to show `addr_street2`, instead of duplicating `addr_street1`. ca7271a

📨 Uses `$request->input()` instead of `Input::all()`, since the `Input` facade [was removed in Laravel 6](https://laravel.com/docs/6.x/upgrade#the-input-facade). e25766f


### How should this be reviewed?

👀

### Any background context you want to provide?

I'll push up a fix to [the missing "debug" job output](https://github.com/DoSomething/chompy/pull/177#discussion_r453897512) in a follow-up PR.

### Relevant tickets

References [Pivotal #172383688](https://www.pivotaltracker.com/story/show/172383688).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
