### PR TITLE
Print record alongside user, mobile user, and post.

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -29,7 +29,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
     /**
      * The mobile user (if different from "primary" user).
-     * 
+     *
      * @var NorthstarUser
      */
     protected $mobileUser;
@@ -129,7 +129,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
             'record.userData' => $this->record->userData,
             'record.postData' => $this->record->postData,
             'user' => Arr::only($user->toArray(), $userFields),
-            'mobile_user' => !empty($this->mobileUser) ? Arr::only($this->mobileUser->toArray(), $userFields) : null,
+            'mobile_user' => ! empty($this->mobileUser) ? Arr::only($this->mobileUser->toArray(), $userFields) : null,
             'post' => Arr::only($post, [
                 'id',
                 'type',


### PR DESCRIPTION
### What's this PR do?

This pull request updates the "debug results" that we return from the `ImportRockTheVoteRecord@handle` method to be a bit more verbose, now that we don't include the `email` and `mobile` fields in the base response.

Here's an example from my testing (where it resolved my main user, and a mobile-only test user):

![Screen Shot 2020-07-15 at 1 44 07 PM](https://user-images.githubusercontent.com/583202/87577822-80227e80-c6a1-11ea-9c02-b7c99526113b.png)


### How should this be reviewed?

👀 

### Any background context you want to provide?

This addresses https://github.com/DoSomething/chompy/pull/177#discussion_r453897512. Because we don't return PII in the `v2/users` response objects, we can no longer easily log the `email` and `mobile` fields here. (And because these `$user` and `$this->mobileUser` values are queried for _all_ jobs, we don't want to always request those fields since it'd add a ton of noise to our logs.)

To make it as easy as possible to debug jobs locally, this form now prints out the `$this->record` input values (from the form, which includes any provided PII) alongside the "safe" `$user` and `$this->mobileUser` and `$post`.

### Relevant tickets

References [Pivotal #172383688](https://www.pivotaltracker.com/story/show/172383688).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
