### PR TITLE
Adds filter for failed RTV reports

### DIFF
--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -74,7 +74,7 @@ class RockTheVoteReportController extends Controller
     {
         $query = RockTheVoteReport::orderBy('id', 'desc');
 
-        if ($request->query('status') == 'failed') {
+        if ($request->query('status') === 'failed') {
             $query->where('status', 'failed');
         }
 

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -67,12 +67,19 @@ class RockTheVoteReportController extends Controller
     /**
      * Display a listing of Rock The Vote reports.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return Response
      */
-    public function index()
+    public function index(Request $request)
     {
+        $query = RockTheVoteReport::orderBy('id', 'desc');
+       
+        if ($request->query('status') == 'failed') {
+            $query->where('status', 'failed');
+        }
+
         return view('pages.rock-the-vote-reports.index', [
-            'data' => RockTheVoteReport::orderBy('id', 'desc')->paginate(15),
+            'data' => $query->paginate(15),
         ]);
     }
 }

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -73,7 +73,7 @@ class RockTheVoteReportController extends Controller
     public function index(Request $request)
     {
         $query = RockTheVoteReport::orderBy('id', 'desc');
-       
+
         if ($request->query('status') == 'failed') {
             $query->where('status', 'failed');
         }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use Chompy\Models\RockTheVoteReport;
 
 class DatabaseSeeder extends Seeder
 {
@@ -11,6 +12,14 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $reportCount = RockTheVoteReport::count();
+
+        // Execute for loop to create unique ID's (which are generated externally by RTV API).
+        for ($i = $reportCount + 1; $i < $reportCount + 10; $i++) {
+            factory(RockTheVoteReport::class)->create([
+              'id' => $i,
+              'status' => $i % 2 === 0 ? 'completed' : 'failed',
+            ]);
+        }
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -17,8 +17,8 @@ class DatabaseSeeder extends Seeder
         // Execute for loop to create unique ID's (which are generated externally by RTV API).
         for ($i = $reportCount + 1; $i < $reportCount + 10; $i++) {
             factory(RockTheVoteReport::class)->create([
-              'id' => $i,
-              'status' => $i % 2 === 0 ? 'completed' : 'failed',
+                'id' => $i,
+                'status' => $i % 2 === 0 ? 'completed' : 'failed',
             ]);
         }
     }

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -33,7 +33,7 @@
                         </a>
                     </li>
                     <li @if (strpos(Request::path(), 'rock-the-vote') !== false)) class="active" @endif>
-                        <a class="nav-item nav-link" href="/import/rock-the-vote">
+                        <a class="nav-item nav-link" href="/rock-the-vote-reports">
                             Rock The Vote
                         </a>
                     </li>


### PR DESCRIPTION
### What's this PR do?

This pull request adds support to filter the table view of RockThe VoteReports to display only ones with a `failed` status. 

It also: 
* modifies the DatabaseSeeder to populate the table with `completed` and `failed` rows. 
* changes Rock The Vote nav item URL to `/rock-the-vote-reports` vs the deprecated CSV upload at `/import/rock-the-vote`

### How should this be reviewed?

👀 

### Any background context you want to provide?

Looking to eventually add support to automatically retry any failed reports, so it'll be useful to filter by them to manually spot check the retries.

### Relevant tickets

References [Pivotal #173611355](https://www.pivotaltracker.com/story/show/173611355).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
