### PR TITLE
Retry importing a failed Rock The Vote report

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ FILESYSTEM_DRIVER=local
 # Rock the Vote
 ROCK_THE_VOTE_API_KEY=
 ROCK_THE_VOTE_PARTNER_ID=
-# Set this to avoid making RTV API calls in development.
+# Used for local development to avoid making API requests.
 ROCK_THE_VOTE_API_FAKER=true
 
 # Chompy UI configuration

--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,8 @@ FILESYSTEM_DRIVER=local
 # Rock the Vote
 ROCK_THE_VOTE_API_KEY=
 ROCK_THE_VOTE_PARTNER_ID=
+# Set this to avoid making RTV API calls in development.
+ROCK_THE_VOTE_API_FAKER=true
 
 # Chompy UI configuration
 IMPORT_TEST_FORM_ENABLED=true

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -94,8 +94,13 @@ class RockTheVoteReportController extends Controller
         $report = RockTheVoteReport::findOrFail($id);
         $retryReport = $report->createRetryReport();
 
+        if (config('services.rock_the_vote.faker')) {
+            return redirect()->back()
+                ->with('status', 'Created fake retry report ' . $retryReport->id);
+        }
+
         ImportRockTheVoteReport::dispatch(\Auth::user(), $retryReport);
 
-        return redirect()->back()->with('status', 'Dispatched retry report ' . $retryReport->id);      
+        return redirect()->back()->with('status', 'Dispatched retry report ' . $retryReport->id);
     }
 }

--- a/app/Http/Controllers/Web/RockTheVoteReportController.php
+++ b/app/Http/Controllers/Web/RockTheVoteReportController.php
@@ -34,7 +34,7 @@ class RockTheVoteReportController extends Controller
     }
 
     /**
-     * Execute API request to create a Rock The Vote Report, and save ID to storage.
+     * Execute API request to create a Rock The Vote Report, and dispatches for import.
      *
      * @param  \Illuminate\Http\Request  $request
      */
@@ -81,5 +81,21 @@ class RockTheVoteReportController extends Controller
         return view('pages.rock-the-vote-reports.index', [
             'data' => $query->paginate(15),
         ]);
+    }
+
+    /**
+     * Creates a retry report for given Rock The Vote Report, and dispatches for import.
+     *
+     * @param  int  $id
+     * @return Response
+     */
+    public function update(Request $request, $id)
+    {
+        $report = RockTheVoteReport::findOrFail($id);
+        $retryReport = $report->createRetryReport();
+
+        ImportRockTheVoteReport::dispatch(\Auth::user(), $retryReport);
+
+        return redirect()->back()->with('status', 'Dispatched retry report ' . $retryReport->id);      
     }
 }

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -89,4 +89,19 @@ class RockTheVoteReport extends Model
     {
         return round(($this->current_index * 100) / $this->row_count);
     }
+
+    /**
+     * Creates a new report with this report's time and since, and saves it to retry_report_id.
+     *
+     * @return RockTheVoteReport
+     */
+    public function createRetryReport()
+    {
+        $retryReport = self::createFromApi($this->since, $this->before);
+
+        $this->retry_report_id = $retryReport->id;
+        $this->save();
+
+        return $retryReport;
+    }
 }

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -18,13 +18,14 @@ class RockTheVoteReport extends Model
      * @var array
      */
     protected $fillable = [
-        'id',
-        'status',
-        'since',
         'before',
-        'row_count',
         'current_index',
         'dispatched_at',
+        'id',
+        'retry_report_id',
+        'row_count',
+        'since',
+        'status',
         'user_id',
     ];
 
@@ -34,9 +35,9 @@ class RockTheVoteReport extends Model
      * @var array
      */
     protected $dates = [
-        'since',
         'before',
         'dispatched_at',
+        'since',
     ];
 
     /**
@@ -48,8 +49,9 @@ class RockTheVoteReport extends Model
      * @var array
      */
     public static $indexes = [
-        'status',
         'dispatched_at',
+        'retry_report_id',
+        'status',
     ];
 
     /**

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -91,7 +91,7 @@ class RockTheVoteReport extends Model
     }
 
     /**
-     * Creates a new report with this report's time and since, and saves it to retry_report_id.
+     * Creates a new report from since and before, and saves it to retry_report_id.
      *
      * @return RockTheVoteReport
      */

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -63,6 +63,22 @@ class RockTheVoteReport extends Model
      */
     public static function createViaApi($since = null, $before = null)
     {
+        $userId = optional(\Auth::user())->northstar_id;
+
+        if (config('services.rock_the_vote.faker')) {
+            $reportId = self::count() + 1;
+
+            info('Creating fake report with ID ' . $reportId);
+
+            return self::create([
+                'id' => $reportId,
+                'since' => $since,
+                'before' => $before,
+                'status' => 'queued',
+                'user_id' => $userId,
+            ]);
+        }
+
         $response = app(RockTheVote::class)->createReport([
             'since' => $since,
             'before' => $before,
@@ -78,7 +94,7 @@ class RockTheVoteReport extends Model
             'since' => $since,
             'before' => $before,
             'status' => $response->status,
-            'user_id' => optional(\Auth::user())->northstar_id,
+            'user_id' => $userId,
         ]);
     }
 
@@ -97,7 +113,7 @@ class RockTheVoteReport extends Model
      */
     public function createRetryReport()
     {
-        $retryReport = self::createFromApi($this->since, $this->before);
+        $retryReport = self::createViaApi($this->since, $this->before);
 
         $this->retry_report_id = $retryReport->id;
         $this->save();

--- a/config/services.php
+++ b/config/services.php
@@ -74,5 +74,7 @@ return [
         'api_key' =>  env('ROCK_THE_VOTE_API_KEY'),
         'partner_id' => env('ROCK_THE_VOTE_PARTNER_ID'),
         'url' => env('ROCK_THE_VOTE_API_URL', 'https://register.rockthevote.com'),
+        // Used for local development to avoid making API requests.
+        'faker' => env('ROCK_THE_VOTE_API_FAKER', false),
     ],
 ];

--- a/database/migrations/2020_07_16_000000_add_retry_report_id_field_to_rock_the_vote_reports_table.php
+++ b/database/migrations/2020_07_16_000000_add_retry_report_id_field_to_rock_the_vote_reports_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddRetryReportIdFieldToRockTheVoteReportsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rock_the_vote_reports', function (Blueprint $table) {
+            $table->unsignedInteger('retry_report_id')->nullable()->after('current_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rock_the_vote_reports', function (Blueprint $table) {
+            $table->dropColumn('retry_report_id');
+        });
+    }
+}

--- a/resources/views/pages/rock-the-vote-reports/index.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/index.blade.php
@@ -19,7 +19,7 @@
         @foreach($data as $key => $report)
             <tr class="row">
               <td class="col-md-2">
-                <a href="/rock-the-vote-reports/{{$report->id}}">
+                <a href="{{ route('rock-the-vote-reports.show', $report) }}">
                   <strong>{{$report->id}}</strong>
                 </a>
               </td>

--- a/resources/views/pages/rock-the-vote-reports/show.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/show.blade.php
@@ -28,7 +28,7 @@
             </p>
         @else
             <form method="POST" action="{{ route('rock-the-vote-reports.update', $report->id) }}">
-                {{ csrf_field()}}
+                {{ csrf_field() }}
                 {{ method_field('PATCH') }}
                 <div>
                     <input type="submit" class="btn btn-primary" value="Retry">

--- a/resources/views/pages/rock-the-vote-reports/show.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/show.blade.php
@@ -22,13 +22,19 @@
             Progress: <strong>{{$report->percentage}}% </strong>(processed <strong>{{$report->current_index}}</strong> rows)
         </p>
     @elseif ($report->status === 'failed')
-        <form method="POST" action="{{ route('rock-the-vote-reports.update', $report->id) }}">
-            {{ csrf_field()}}
-            {{ method_field('PATCH') }}
-            <div>
-                <input type="submit" class="btn btn-primary" value="Retry">
-            </div>
-        </form>
+        @if ($report->retry_report_id)
+            <p>
+                Retry Report: <a href="{{ route('rock-the-vote-reports.show', $report->retry_report_id) }}"><strong>#{{$report->retry_report_id}}</strong></a>.
+            </p>
+        @else
+            <form method="POST" action="{{ route('rock-the-vote-reports.update', $report->id) }}">
+                {{ csrf_field()}}
+                {{ method_field('PATCH') }}
+                <div>
+                    <input type="submit" class="btn btn-primary" value="Retry">
+                </div>
+            </form>
+        @endif
     @elseif ($report->status === 'complete')
         <p>
             Imported: <strong>{{$report->dispatched_at}}</strong>

--- a/resources/views/pages/rock-the-vote-reports/show.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/show.blade.php
@@ -18,13 +18,21 @@
         Status: <strong>{{$report->status}}</strong>
     </p>
     @if ($report->status === 'building')
-    <p>
-        Progress: <strong>{{$report->percentage}}% </strong>(processed <strong>{{$report->current_index}}</strong> rows)
-    </p>
+        <p>
+            Progress: <strong>{{$report->percentage}}% </strong>(processed <strong>{{$report->current_index}}</strong> rows)
+        </p>
+    @elseif ($report->status === 'failed')
+        <form method="POST" action="{{ route('rock-the-vote-reports.update', $report->id) }}">
+            {{ csrf_field()}}
+            {{ method_field('PATCH') }}
+            <div>
+                <input type="submit" class="btn btn-primary" value="Retry">
+            </div>
+        </form>
     @elseif ($report->status === 'complete')
-    <p>
-        Imported: <strong>{{$report->dispatched_at}}</strong>
-    </p>
+        <p>
+            Imported: <strong>{{$report->dispatched_at}}</strong>
+        </p>
     @endif
     <hr />
     <small>This report was created by {{$report->user_id}} on {{$report->created_at}}.</small>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,7 @@ $router->post('upload/{importType}', 'ImportFileController@upload')->name('impor
 Route::resource('import-files', 'ImportFileController', ['only' => ['index', 'show']]);
 
 Route::resource('rock-the-vote-reports', 'RockTheVoteReportController', [
-    'except' => ['delete', 'update'],
+    'except' => ['delete'],
 ]);
 
 Route::resource('users', 'UserController', ['only' => ['show']]);

--- a/tests/Unit/Models/RockTheVoteReportTest.php
+++ b/tests/Unit/Models/RockTheVoteReportTest.php
@@ -91,4 +91,37 @@ class RockTheVoteReportTest extends TestCase
             \Config::set('services.rock_the_vote.faker', 'true');
         }
     }
+
+    /**
+     * Test that createRetryReport creates a report and sets retry_report_id.
+     *
+     * @return void
+     */
+    public function testCreateRetryReport()
+    {
+        $isFaker = config('services.rock_the_vote.faker');
+
+        if ($isFaker) {
+            \Config::set('services.rock_the_vote.faker', false);
+        }
+
+        $this->rockTheVoteMock->shouldReceive('createReport')->andReturn((object) [
+            'status'=> 'queued',
+            'status_url' => 'https://register.rockthevote.com/api/v4/registrant_reports/17',
+        ]);
+
+        $report = factory(RockTheVoteReport::class)->create([
+            'status' => 'failed',
+        ]);
+
+        $this->assertEquals($report->retry_report_id, null);
+
+        $retryReport = $report->createRetryReport();
+
+        $this->assertEquals($report->retry_report_id, $retryReport->id);
+
+        if ($isFaker) {
+            \Config::set('services.rock_the_vote.faker', 'true');
+        }
+    }
 }

--- a/tests/Unit/Models/RockTheVoteReportTest.php
+++ b/tests/Unit/Models/RockTheVoteReportTest.php
@@ -15,6 +15,12 @@ class RockTheVoteReportTest extends TestCase
      */
     public function testCreateViaApiWithValidResponse()
     {
+        $isFaker = config('services.rock_the_vote.faker');
+
+        if ($isFaker) {
+            \Config::set('services.rock_the_vote.faker', false);
+        }
+
         $this->rockTheVoteMock->shouldReceive('createReport')->andReturn((object) [
             'status'=> 'queued',
             'status_url' => 'https://register.rockthevote.com/api/v4/registrant_reports/17',
@@ -30,6 +36,10 @@ class RockTheVoteReportTest extends TestCase
         $this->assertEquals($report->before, $before);
         $this->assertEquals($report->status, 'queued');
         $this->assertEquals($report->user_id, null);
+
+        if ($isFaker) {
+            \Config::set('services.rock_the_vote.faker', 'true');
+        }
     }
 
     /**
@@ -39,11 +49,21 @@ class RockTheVoteReportTest extends TestCase
      */
     public function testCreateViaApiWithInvalidResponseType()
     {
+        $isFaker = config('services.rock_the_vote.faker');
+
+        if ($isFaker) {
+            \Config::set('services.rock_the_vote.faker', false);
+        }
+
         $this->rockTheVoteMock->shouldReceive('createReport')->andReturn('test');
 
         $this->expectException(ErrorException::class);
 
         RockTheVoteReport::createViaApi();
+
+        if ($isFaker) {
+            \Config::set('services.rock_the_vote.faker', 'true');
+        }
     }
 
     /**
@@ -53,6 +73,12 @@ class RockTheVoteReportTest extends TestCase
      */
     public function testCreateViaApiWithMissingStatusUrl()
     {
+        $isFaker = config('services.rock_the_vote.faker');
+
+        if ($isFaker) {
+            \Config::set('services.rock_the_vote.faker', false);
+        }
+
         $this->rockTheVoteMock->shouldReceive('createReport')->andReturn((object) [
             'status'=> 'queued',
         ]);
@@ -60,5 +86,9 @@ class RockTheVoteReportTest extends TestCase
         $this->expectException(ErrorException::class);
 
         RockTheVoteReport::createViaApi();
+
+        if ($isFaker) {
+            \Config::set('services.rock_the_vote.faker', 'true');
+        }
     }
 }

--- a/tests/Unit/Models/RockTheVoteReportTest.php
+++ b/tests/Unit/Models/RockTheVoteReportTest.php
@@ -102,17 +102,14 @@ class RockTheVoteReportTest extends TestCase
             'since' => '2019-12-19 00:00:00',
         ];
 
-        $report = factory(RockTheVoteReport::class)
-          ->create(array_merge($params, ['status' => 'failed']));
+        $report = factory(RockTheVoteReport::class)->create($params);
 
-        $this->rockTheVoteMock->shouldReceive('createReport')
-          ->with($params)
-          ->andReturn((object) [
+        $this->assertEquals($report->retry_report_id, null);
+
+        $this->rockTheVoteMock->shouldReceive('createReport')->with($params)->andReturn((object) [
             'status'=> 'queued',
             'status_url' => 'https://register.rockthevote.com/api/v4/registrant_reports/17',
         ]);
-
-        $this->assertEquals($report->retry_report_id, null);
 
         $retryReport = $report->createRetryReport();
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a "Retry" button to the UI when viewing a RTV report that has a `failed` status, and hasn't been retried yet. Under the hood, this happens per the following changes:

* Adds DB migration / model attribute for a new `retry_report_id` int column on the `rock_the_vote_reports` table

* Adds a `createRetryReport` method to the `RockTheVoteReport` model. This method uses the report's `since` and `before` parameters to execute an RTV API request to create a new report, and sets the new ID from API response to its `retry_report_id`.

* Adds the `update` route and handler for the `RockTheVoteReport` resource, which will call `createRetryReport` for a given `RockTheVoteReport` id

Example retry form:

<img src="https://user-images.githubusercontent.com/1236811/87992970-40db9f80-ca9e-11ea-89b5-3c3027b47017.png">

Example retried report:

<img src="https://user-images.githubusercontent.com/1236811/87993001-5650c980-ca9e-11ea-9846-1f0bd83f4567.png">

### How should this be reviewed?

👀 

### Any background context you want to provide?

* This PR also adds a `faker` configuration key for the Rock The Vote service, which I wanted in order to make and test the UI updates without sending real API requests to the RTV, which would unnecessarily generate reports. 

* I plan to add additional test coverage for the update form in a future PR (verify when Retry button is visible, that import job is dispatched). Left it out for now in hopes of keeping this easier to review

### Relevant tickets

References [Pivotal #173611355](https://www.pivotaltracker.com/story/show/173611355).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
