### PR TITLE
Retry failed reports via ImportRockTheVoteReport job

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteReport.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteReport.php
@@ -57,7 +57,7 @@ class ImportRockTheVoteReport implements ShouldQueue
         if ($status !== 'complete') {
             $this->report->save();
 
-            // If non-failed, status may be queued or building, so try importing again in 2 minutes. 
+            // If non-failed, status may be queued or building, so try importing again in 2 minutes.
             if ($status !== 'failed') {
                 return self::dispatch($this->user, $this->report)->delay(now()->addMinutes(2));
             }

--- a/resources/views/pages/rock-the-vote-reports/index.blade.php
+++ b/resources/views/pages/rock-the-vote-reports/index.blade.php
@@ -30,7 +30,13 @@
                 {{$report->before}}
               </td>
               <td class="col-md-2">
-                {{$report->status}}
+                @if ($report->retry_report_id)
+                  retried <a href="{{ route('rock-the-vote-reports.show', $report->retry_report_id) }}">
+                    #{{ $report->retry_report_id }}
+                  </a>
+                @else
+                  {{$report->status}}
+                @endif
               </td>
               <td class="col-md-2">
                 {{$report->dispatched_at}}

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteReportTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteReportTest.php
@@ -13,8 +13,8 @@ use Chompy\Jobs\ImportRockTheVoteReport;
 class ImportRockTheVoteReportTest extends TestCase
 {
     /**
-     * Test that report is not downloaded and job is retried if status is building.
-     *
+     * Test that a job is dispatched to import this report again after 2 minutes if status building.
+     * 
      * @return void
      */
     public function testReportStatusBuilding()

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteReportTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteReportTest.php
@@ -14,7 +14,7 @@ class ImportRockTheVoteReportTest extends TestCase
 {
     /**
      * Test that a job is dispatched to import this report again after 2 minutes if status building.
-     * 
+     *
      * @return void
      */
     public function testReportStatusBuilding()

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteReportTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteReportTest.php
@@ -106,7 +106,7 @@ class ImportRockTheVoteReportTest extends TestCase
 
         $importRockTheVoteReportJob->handle();
 
-        Bus::assertDispatched(ImportRockTheVoteReport::class, function ($job) use (&$report, &$user) {
+        Bus::assertDispatched(ImportRockTheVoteReport::class, function ($job) use (&$report) {
             $params = $job->getParameters();
 
             $this->assertEquals($params['report']->id, $report->retry_report_id);

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteReportTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteReportTest.php
@@ -29,6 +29,7 @@ class ImportRockTheVoteReportTest extends TestCase
             'record_count' => 117,
             'current_index' => 3,
         ]);
+        $this->rockTheVoteMock->shouldNotReceive('createReport');
         $this->rockTheVoteMock->shouldNotReceive('getReportByUrl');
 
         $importRockTheVoteReportJob = new ImportRockTheVoteReport($user, $report);
@@ -68,6 +69,7 @@ class ImportRockTheVoteReportTest extends TestCase
             'record_count' => 0,
             'current_index' => 0,
         ]);
+        $this->rockTheVoteMock->shouldNotReceive('createReport');
         $this->rockTheVoteMock->shouldNotReceive('getReportByUrl');
 
         $importRockTheVoteReportJob = new ImportRockTheVoteReport($user, $report);
@@ -132,7 +134,7 @@ class ImportRockTheVoteReportTest extends TestCase
             'record_count' => 1112,
             'current_index' => 1112,
         ]);
-
+        $this->rockTheVoteMock->shouldNotReceive('createReport');
         $this->rockTheVoteMock->shouldReceive('getReportByUrl');
 
         $importRockTheVoteReportJob = new ImportRockTheVoteReport($user, $report);


### PR DESCRIPTION
### What's this PR do?

This pull request continues building out the retry feature introduced in #182, modifying the `ImportRockTheVoteReport` job to better handle when its report status is `failed`:

* If the report hasn't been retried, create a retry report and dispatch the new retry report ID for import, discarding the current job for the failed report.

* If the report has been retried, discard the current job for the failed report. The only time we'd possibly run into this is when an admin manually creates a retry via UI before the hourly import runs to create the retry.

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

🦎 

### Relevant tickets

References [Pivotal #173611355](https://www.pivotaltracker.com/story/show/173611355).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
