### PR TITLE
Feature flag automatic retry of failed reports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,9 @@ NEWS_SUBSCRIPTION_RESET_TYPE=breakdown-activate-account
 ## Optional config overrides - Rock The Vote Import
 ##
 
+# Whether to retry a failed report when importing from console command. 
+ROCK_THE_VOTE_RETRY_FAILED_REPORTS_ENABLED=false
+
 # Whether to update existing users' SMS subscriptions per opt-in via RTV registration form.
 ROCK_THE_VOTE_UPDATE_USER_SMS_ENABLED=false
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteReport.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteReport.php
@@ -62,6 +62,10 @@ class ImportRockTheVoteReport implements ShouldQueue
                 return self::dispatch($this->user, $this->report)->delay(now()->addMinutes(2));
             }
 
+            if (config('import.rock_the_vote.retry_failed_reports') !== 'true') {
+                return;
+            }
+
             // If failed and we've already retried this report, log the oddity and discard this job.
             if ($this->report->retry_report_id) {
                 info('Report ' . $reportId . ' already has retry report ' . $this->report->retry_report_id);

--- a/config/import.php
+++ b/config/import.php
@@ -34,6 +34,8 @@ return [
     ],
     // Configuration for a Rock The Vote voter registration import.
     'rock_the_vote' => [
+        // Whether to automatically retry a report with failed status.
+        'retry_failed_reports' => env('ROCK_THE_VOTE_RETRY_FAILED_REPORTS_ENABLED', false),
         // Constants to use when creating a post.
         'post' => [
             'action_id' => env('ROCK_THE_VOTE_POST_ACTION_ID', 954),


### PR DESCRIPTION
### What's this PR do?

This pull request checks to see if a new config variable, `ROCK_THE_VOTE_RETRY_FAILED_REPORTS_ENABLED` is set to `true` before retrying a failed report via console command (introduced in #183).

We've seen that retrying certain reports' `since` and `before` parameters returns a 500 error from the RTV API, so we rolled back the deploy of #183. TBD whether we'll end up setting `ROCK_THE_VOTE_RETRY_FAILED_REPORTS_ENABLED` at all - but figured the feature flag wouldn't hurt for now vs. deleting all the code and tests that #183 introduced.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I tried restoring the default configuration in `tearDown`, like we're doing for #182 -- but the tests fail with:
```
Illuminate\Contracts\Container\BindingResolutionException: Target class [config] does not exist.
```
and
```
ReflectionException: Class config does not exist
```

I still can't figure out why this is happening, but got it working by setting the `config` back in each individual test for now 😤 

### Relevant tickets

References [Pivotal #173611355](https://www.pivotaltracker.com/story/show/173611355).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
