### PR TITLE
Update README.md to remove php 7.3 reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ To get started with development, you'll first need local instances of [Northstar
 Next, fork and clone this repository, and [add it to your Homestead](https://github.com/DoSomething/communal-docs/blob/master/Homestead/readme.md). SSH into your VirtualBox, navigate to your Chompy directory, and run the installation steps:
 
 ```sh
-# First, switch to PHP 7.3
-$ php73
-
 # Install dependencies
 $ composer install && npm install
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates the readme to remove the step about switching to php 7.3.

### How should this be reviewed?

Is this accurate?

### Any background context you want to provide?

We're on 7.4 now!

### Relevant tickets

🤠 

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
