### PR TITLE
Don't send activate account email when creating user with Step 1 status

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -60,7 +60,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
 
         info('Processing Rock The Vote record', ['started_registration' => $postDetails['Started registration']]);
 
-        $user = $this->getUser($this->userData['id'], $this->userData['email'], $this->userData['mobile']);
+        $user = $this->getUser();
 
         if (! $user) {
             info('User not found, creating user');
@@ -97,7 +97,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
         $user = $this->updateUserVoterRegistrationStatusIfChanged($user);
 
         // If registration does not have a mobile provided, no need to update SMS subscription.
-        if ($this->userData['mobile']) {
+        if (isset($this->userData['mobile'])) {
             $user = $this->updateUserSmsSubscriptionIfChanged($user);
         }
 
@@ -150,10 +150,10 @@ class ImportRockTheVoteRecord implements ShouldQueue
      * @param string $mobile
      * @return NorthstarUser
      */
-    private function getUser($id, $email, $mobile)
+    private function getUser()
     {
-        if ($id) {
-            $user = gateway('northstar')->asClient()->getUser($id);
+        if ($this->userData['id']) {
+            $user = gateway('northstar')->asClient()->getUser($this->userData['id']);
 
             if ($user && $user->id) {
                 info('Found user by id', ['user' => $user->id]);
@@ -162,8 +162,8 @@ class ImportRockTheVoteRecord implements ShouldQueue
             }
         }
 
-        if ($email) {
-            $user = gateway('northstar')->asClient()->getUserByEmail($email);
+        if ($this->userData['email']) {
+            $user = gateway('northstar')->asClient()->getUserByEmail($this->userData['email']);
 
             if ($user && $user->id) {
                 info('Found user by email', ['user' => $user->id]);
@@ -172,11 +172,11 @@ class ImportRockTheVoteRecord implements ShouldQueue
             }
         }
 
-        if (! $mobile) {
+        if (! isset($this->userData['mobile'])) {
             return null;
         }
 
-        $user = gateway('northstar')->asClient()->getUserByMobile($mobile);
+        $user = gateway('northstar')->asClient()->getUserByMobile($this->userData['mobile']);
 
         if ($user && $user->id) {
             info('Found user by mobile', ['user' => $user->id]);

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -145,9 +145,6 @@ class ImportRockTheVoteRecord implements ShouldQueue
     /**
      * Check for user first by id, next by email, last by mobile.
      *
-     * @param string $id
-     * @param string $email
-     * @param string $mobile
      * @return NorthstarUser
      */
     private function getUser()

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -45,7 +45,7 @@ class RockTheVoteRecord
          * At step 1, a user has only provided their email and zip, but Rock The Vote will sometimes
          * mysteriously send through data for fields populated in later steps. We don't want to save
          * any other data until the status is at least step 2.
-         * @see /docs/imports/readme.MD#status
+         * @see /docs/imports/README.md#status
          */
         if ($rtvStatus !== 'step-1') {
             $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -42,9 +42,10 @@ class RockTheVoteRecord
         ];
 
         /**
-         * At step 1, a user is not asked for PII or prompted to subscribe, but the Rock The Vote
-         * sometimes mysteriously sends through values for these fields. We don't want to save them
-         * until they have been collected in step 2.
+         * At step 1, a user has only provided their email and zip, but Rock The Vote will sometimes
+         * mysteriously send through data for fields populated in later steps. We don't want to save
+         * any other data until the status is at least step 2.
+         * @see /docs/imports/readme.MD#status
          */
         if ($rtvStatus !== 'step-1') {
             $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -59,13 +59,14 @@ class RockTheVoteRecord
                 'email_subscription_status' => $emailOptIn,
                 'email_subscription_topics' => $emailOptIn ? explode(',', $config['user']['email_subscription_topics']) : [],
             ]);
-        }
 
-        if ($mobile) {
-            $smsOptIn = str_to_boolean($record[static::$smsOptInFieldName]);
+            // If a mobile was provided, set SMS subscriptions per opt-in value.
+            if ($mobile) {
+                $smsOptIn = str_to_boolean($record[static::$smsOptInFieldName]);
 
-            $this->userData['sms_status'] = $smsOptIn ? SmsStatus::$active : SmsStatus::$stop;
-            $this->userData['sms_subscription_topics'] = $smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
+                $this->userData['sms_status'] = $smsOptIn ? SmsStatus::$active : SmsStatus::$stop;
+                $this->userData['sms_subscription_topics'] = $smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
+            }
         }
 
         $this->postData = [

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -30,8 +30,6 @@ class RockTheVoteRecord
             $config = ImportType::getConfig(ImportType::$rockTheVote);
         }
 
-        $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);
-        $mobile = isset($record[static::$mobileFieldName]) && is_valid_mobile($record[static::$mobileFieldName]) ? $record[static::$mobileFieldName] : null;
         $rtvStatus = $this->parseVoterRegistrationStatus($record['Status'], $record['Finish with State']);
 
         $this->userData = [
@@ -49,19 +47,21 @@ class RockTheVoteRecord
          * until they have been collected in step 2.
          */
         if ($rtvStatus !== 'step-1') {
+            $emailOptIn = str_to_boolean($record['Opt-in to Partner email?']);
+
             $this->userData = array_merge($this->userData, [
                 'addr_street1' => $record['Home address'],
                 'addr_street2' => $record['Home unit'],
                 'addr_city' => $record['Home city'],
-                'first_name' => $record['First name'],
-                'last_name' => $record['Last name'],
-                'mobile' => $mobile,
                 'email_subscription_status' => $emailOptIn,
                 'email_subscription_topics' => $emailOptIn ? explode(',', $config['user']['email_subscription_topics']) : [],
+                'first_name' => $record['First name'],
+                'last_name' => $record['Last name'],
+                'mobile' => isset($record[static::$mobileFieldName]) && is_valid_mobile($record[static::$mobileFieldName]) ? $record[static::$mobileFieldName] : null,
             ]);
 
-            // If a mobile was provided, set SMS subscriptions per opt-in value.
-            if ($mobile) {
+            // If a mobile was provided, set SMS subscription per opt-in value.
+            if ($this->userData['mobile']) {
                 $smsOptIn = str_to_boolean($record[static::$smsOptInFieldName]);
 
                 $this->userData['sms_status'] = $smsOptIn ? SmsStatus::$active : SmsStatus::$stop;

--- a/database/faker/FakerRockTheVoteReportRow.php
+++ b/database/faker/FakerRockTheVoteReportRow.php
@@ -26,7 +26,7 @@ class FakerRockTheVoteReportRow extends Base
             'Finish with State' => 'Yes',
             'Pre-Registered' => 'No',
             'Started registration' => $this->daysAgoInRockTheVoteFormat(),
-            'Status' => 'Step 1',
+            'Status' => 'Step 2',
             'Tracking Source' => 'ads',
             'Opt-in to Partner email?' => 'Yes',
             'Opt-in to Partner SMS/robocall' => 'No',

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -161,7 +161,7 @@ If the RTV Status is past Step 1, we also include these fields when creating a n
 
 ## Notes
 
-- The conditional logic that checks for `Step 1` values when creating a user was introduced in [#190](https://github.com/DoSomething/chompy/pull/190). Prior to this change, the import would use all given fields when creating a new user (details in the PR its linked Pivotal story).
+- The conditional logic that checks for `Step 1` values when creating a user was introduced in [September 2020](https://github.com/DoSomething/chompy/pull/190). Prior to this change, the import would use all given fields when creating a new user (details in the PR its linked Pivotal story).
 
 - An existing user's SMS subscription is only updated once per unique registration. This is to avoid a scenario where a registration may appear twice within our hourly imports, and we could re-subscribe a user who unsubscribed after the first import that subscribed them was processed.
 

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -36,8 +36,6 @@ The other status values returned from RTV are:
 
 - `step-1`: a person entered email/ZIP code on the first page, then stopped.
 
-  - Note -- we've seen profile info entered in rows that are on Step 1, and TBD why this happens sometimes.
-
 - `step-2`: user got to the second page to start filling out their personal info, but did not finish
 
 - `step-3`/`step-4`: a person finished entering their registration information, but either (1) did not click to open/print their paper registration form, or (2) were eligible to finish on their state website, but did not click through
@@ -135,9 +133,21 @@ If an existing user **opts-out** of voting-related SMS messaging from DS:
 
 ## New Users
 
-If the `Tracking Source` doesn't contain a NS ID, the import searches for an existing user by email, and last by mobile number. If a user is still not found, then a new user is created using the following record data:
+If the `Tracking Source` doesn't contain a NS ID, the import searches for an existing user by email, and last by mobile number. If a user is still not found, then a new user is created.
 
-- PII: First name, last name, address, city, zip
+If the RTV Status is Step 1, we create a new user with these fields:
+
+- Email
+
+- Zip
+
+- Voter Registration Status
+
+If the RTV Status is past Step 1, we also include these fields when creating a new user:
+
+- First and last name
+
+- Address and city
 
 - Email Subscription
 
@@ -149,9 +159,9 @@ If the `Tracking Source` doesn't contain a NS ID, the import searches for an exi
 
   - If user opts-out of SMS messaging from DS, user's `sms_status` will be set to `stop` and `sms_subscription_topics` will be set to empty.
 
-- Voter Registration Status
-
 ## Notes
+
+- The conditional logic that checks for `Step 1` values when creating a user was introduced in [#190](https://github.com/DoSomething/chompy/pull/190). Prior to this change, the import would use all given fields when creating a new user (details in the PR its linked Pivotal story).
 
 - An existing user's SMS subscription is only updated once per unique registration. This is to avoid a scenario where a registration may appear twice within our hourly imports, and we could re-subscribe a user who unsubscribed after the first import that subscribed them was processed.
 

--- a/resources/views/components/alert-success.blade.php
+++ b/resources/views/components/alert-success.blade.php
@@ -1,7 +1,7 @@
 @if (is_array($data))
-    @foreach ($data as $entityName => $entityData)
+    @foreach ((array) $data as $entityName => $entityData)
         <li>{{ $entityName }}<ul>
-            @foreach ($entityData as $fieldName => $value)
+            @foreach ((array) $entityData as $fieldName => $value)
                 <li>
                     {{ $fieldName }}: <strong>{{ is_array($value) ? json_encode($value) : $value }}</strong>
                 </li>

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -42,6 +42,30 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
+     * Test that a password reset email is not set when a new user is created with Step 1 status.
+     *
+     * @return void
+     */
+    public function testDoesNotSendPasswordResetWhenCreatesUserWithStep1()
+    {
+        $userId = $this->faker->northstar_id;
+        $row = $this->faker->rockTheVoteReportRow([
+            'Status' => 'Step 1',
+        ]);
+        $importFile = factory(ImportFile::class)->create();
+
+        $this->northstarMock->shouldReceive('getUser')->andReturn(null);
+        $this->mockCreateNorthstarUser(['id' => $userId]);
+        $this->northstarMock->shouldNotReceive('sendPasswordReset');
+        $this->rogueMock->shouldReceive('getPosts')->andReturn(null);
+        $this->rogueMock->shouldReceive('createPost')->andReturn([
+            'data' => $this->faker->rogueVoterRegPost(),
+        ]);
+
+        ImportRockTheVoteRecord::dispatch($row, $importFile);
+    }
+
+    /**
      * Test that user is not created if user is found.
      *
      * @return void

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -55,6 +55,31 @@ class RockTheVoteRecordTest extends TestCase
     }
 
     /**
+     * Test that userData contains a smaller dataset when RTV status is Step 1.
+     *
+     * @return void
+     */
+    public function testStep1StatusUserData()
+    {
+        $exampleRow = $this->faker->rockTheVoteReportRow([
+            'Status' => 'Step 1',
+        ]);
+        $config = ImportType::getConfig(ImportType::$rockTheVote);
+
+        $record = new RockTheVoteRecord($exampleRow);
+
+        $this->assertEquals($record->userData, [
+            'addr_zip' => $exampleRow['Home zip code'],
+            'email' => $exampleRow['Email address'],
+            'id' => null,
+            'referrer_user_id' => null,
+            'source' => config('services.northstar.client_credentials.client_id'),
+            'source_detail' => $config['user']['source_detail'],
+            'voter_registration_status' => 'step-1',
+        ]);
+    }
+
+    /**
      * Test that user is not subscribed if they did not opt-in.
      *
      * @return void


### PR DESCRIPTION
### What's this PR do?

This pull request modifies create user logic in the Rock The Vote import, checking to see if the status is `Step 1`. 

If it is -- only include the RTV record collected from the user at Step 1: email and zip. 

If it isn't, use all data provided within the RTV record. 



### How should this be reviewed?

👀 

### Any background context you want to provide?

We have an open question out to Rock The Vote to understand why we see values for some fields that shouldn't have been collected yet at Step 1, but for now this code change will prevent us from sending Activate Account emails to users who haven't been prompted with an email opt-in form yet.


### Relevant tickets

References [Pivotal #174844127](https://www.pivotaltracker.com/story/show/174844127).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
