### PR TITLE
Do not add phone number to users who did not opt in to receive SMS messages

### DIFF
--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -58,15 +58,19 @@ class RockTheVoteRecord
                 'email_subscription_topics' => $emailOptIn ? explode(',', $config['user']['email_subscription_topics']) : [],
                 'first_name' => $record['First name'],
                 'last_name' => $record['Last name'],
-                'mobile' => isset($record[static::$mobileFieldName]) && is_valid_mobile($record[static::$mobileFieldName]) ? $record[static::$mobileFieldName] : null,
             ]);
 
-            // If a mobile was provided, set SMS subscription per opt-in value.
-            if ($this->userData['mobile']) {
-                $smsOptIn = str_to_boolean($record[static::$smsOptInFieldName]);
+            // If a the user opted in to SMS messaging, add their mobile number
+            $smsOptIn = str_to_boolean($record[static::$smsOptInFieldName]);
+            if ($smsOptIn) {
+                $this->userData['mobile'] = isset($record[static::$mobileFieldName]) && is_valid_mobile($record[static::$mobileFieldName]) ? $record[static::$mobileFieldName] : null;
 
-                $this->userData['sms_status'] = $smsOptIn ? SmsStatus::$active : SmsStatus::$stop;
-                $this->userData['sms_subscription_topics'] = $smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
+                // Only set SMS subscription fields if mobile is included and valid
+                if($this->userData['mobile']) {
+                    $this->userData['sms_status'] = $smsOptIn ? SmsStatus::$active : SmsStatus::$stop;
+                    $this->userData['sms_subscription_topics'] = $smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
+                }
+
             }
         }
 

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -58,19 +58,18 @@ class RockTheVoteRecord
                 'email_subscription_topics' => $emailOptIn ? explode(',', $config['user']['email_subscription_topics']) : [],
                 'first_name' => $record['First name'],
                 'last_name' => $record['Last name'],
+                'mobile' => null,
+                'sms_status' => null,
             ]);
 
-            // If a the user opted in to SMS messaging, add their mobile number
+            // If a the user opted in to SMS messaging, add their mobile number and SMS subscription fields
             $smsOptIn = str_to_boolean($record[static::$smsOptInFieldName]);
             if ($smsOptIn) {
-                $this->userData['mobile'] = isset($record[static::$mobileFieldName]) && is_valid_mobile($record[static::$mobileFieldName]) ? $record[static::$mobileFieldName] : null;
-
-                // Only set SMS subscription fields if mobile is included and valid
-                if($this->userData['mobile']) {
-                    $this->userData['sms_status'] = $smsOptIn ? SmsStatus::$active : SmsStatus::$stop;
+                if (isset($record[static::$mobileFieldName]) && is_valid_mobile($record[static::$mobileFieldName])) {
+                    $this->userData['mobile'] = $record[static::$mobileFieldName];
+                    $this->userData['sms_status'] = SmsStatus::$active;
                     $this->userData['sms_subscription_topics'] = $smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
-                }
-
+                }                
             }
         }
 

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -69,7 +69,7 @@ class RockTheVoteRecord
                     $this->userData['mobile'] = $record[static::$mobileFieldName];
                     $this->userData['sms_status'] = SmsStatus::$active;
                     $this->userData['sms_subscription_topics'] = $smsOptIn ? explode(',', $config['user']['sms_subscription_topics']) : [];
-                }                
+                }
             }
         }
 

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -475,7 +475,7 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Test that import user's mobile is updated if they don't have one set, and no other user owns
+     * Test that import user's mobile is updated only if they don't have one set already, and no other user owns
      * the mobile number, and they have opted-in to SMS messaging.
      *
      * @return void
@@ -491,10 +491,9 @@ class ImportRockTheVoteRecordTest extends TestCase
             'Opt-in to Partner SMS/robocall' => 'Yes',
         ]);
         // If the mobile is not owned by any other users, we can update our import user with it.
-        // $this->northstarMock->shouldReceive('getUser')->andReturn(null);
         $this->northstarMock->shouldReceive('getUserByMobile')
-        ->with($phoneNumber)
-        ->andReturn(null);
+                                ->with($phoneNumber)
+                                ->andReturn(null);
         $this->northstarMock->shouldReceive('updateUser')
             ->with($user->id, [
                 'mobile' => $phoneNumber,
@@ -525,7 +524,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             'Opt-in to Partner SMS/robocall' => 'No',
         ]);
         // If the mobile is not owned by any other users, we can update our import user with it.
-        $this->northstarMock->shouldNotReceive('getUser');
+        $this->northstarMock->shouldNotReceive('getUserByMobile');
         $this->northstarMock->shouldNotReceive('updateUser');
 
         $job = new ImportRockTheVoteRecord($row, factory(ImportFile::class)->create());

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -523,7 +523,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             'Phone' => $phoneNumber,
             'Opt-in to Partner SMS/robocall' => 'No',
         ]);
-        // If the mobile is not owned by any other users, we can update our import user with it.
+        // We won't try to match on SMS or update this user
         $this->northstarMock->shouldNotReceive('getUserByMobile');
         $this->northstarMock->shouldNotReceive('updateUser');
 

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -80,7 +80,8 @@ class RockTheVoteRecordTest extends TestCase
     }
 
     /**
-     * Test that user is not subscribed if they did not opt-in.
+     * Test that if a user did not opt in to SMS or email, then their phone number
+     * is not saved and they are not subscribed.
      *
      * @return void
      */
@@ -94,10 +95,14 @@ class RockTheVoteRecordTest extends TestCase
 
         $record = new RockTheVoteRecord($exampleRow);
 
+        // Email
         $this->assertEquals($record->userData['email_subscription_status'], false);
         $this->assertEquals($record->userData['email_subscription_topics'], []);
-        $this->assertEquals($record->userData['sms_status'], 'stop');
-        $this->assertEquals($record->userData['sms_subscription_topics'], []);
+
+        // SMS
+        $this->assertEquals($record->userData['mobile'], null);
+        $this->assertEquals($record->userData['sms_status'], null);
+        $this->assertArrayNotHasKey('sms_subscription_topics', $record->userData);
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request updates some fun business logic. We only want to save a user's phone number to a new or existing account IF the user has opted in to receiving SMS messaging. Previously in these cases, we would save the phone number and set their `sms_status` to `stop` but that was confusing when looking at the data because it looks like these folks have actively unsubscribed, when really they were never subscribed in the first place.

### How should this be reviewed?

The only change this should make should be to not save mobile number to a user's profile if they have not opted in to sms. Did I update tests properly? Should I write any additional tests?

### Any background context you want to provide?

Check out the thread on the pivotal ticket for more context!

### Relevant tickets

References [Pivotal #174361978](https://www.pivotaltracker.com/story/show/174361978).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
