### PR TITLE
Validate RTV "Started registration" value

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -65,6 +65,7 @@ class ImportRockTheVoteRecord implements ShouldQueue
     {
         if (!$this->record) {
             $this->importFile->incrementSkipCount();
+
             return [];
         }
 

--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -48,9 +48,11 @@ class ImportRockTheVoteRecord implements ShouldQueue
         try {
             $this->record = new RockTheVoteRecord($record, $this->config);
         } catch (ValidationException $e) {
+            $this->exception = $e;
+
             return;
         }
-        
+
         $this->userData = $this->record->userData;
         $this->postData = $this->record->postData;
         $this->smsOptIn = isset($this->userData['sms_status']) && $this->userData['sms_status'] == SmsStatus::$active;
@@ -63,10 +65,12 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function handle()
     {
-        if (!$this->record) {
+        if (! $this->record) {
             $this->importFile->incrementSkipCount();
 
-            return [];
+            return [
+                'response' => ['message' => $this->exception->getMessage()],
+            ];
         }
 
         $postDetails = $this->record->getPostDetails();

--- a/app/RockTheVoteRecord.php
+++ b/app/RockTheVoteRecord.php
@@ -3,6 +3,8 @@
 namespace Chompy;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 
 class RockTheVoteRecord
 {
@@ -19,6 +21,11 @@ class RockTheVoteRecord
     public static $smsOptInFieldName = 'Opt-in to Partner SMS/robocall';
 
     /**
+     * @var string
+     */
+    public static $startedRegistrationFieldName = 'Started registration';
+
+    /**
      * Parses values to send to DS API from given CSV record, using given config.
      *
      * @param array $record
@@ -26,6 +33,20 @@ class RockTheVoteRecord
      */
     public function __construct($record, $config = null)
     {
+        $validator = Validator::make($record, [
+            static::$startedRegistrationFieldName => 'required|date',
+        ]);
+
+        if ($validator->fails()) {
+            $errorMessages = $validator->errors()->all();
+
+            info('Invalid Rock The Vote record', array_merge([
+                static::$startedRegistrationFieldName => $record[static::$startedRegistrationFieldName],
+            ], $errorMessages));
+
+            throw ValidationException::withMessages($errorMessages);
+        }
+
         if (! $config) {
             $config = ImportType::getConfig(ImportType::$rockTheVote);
         }

--- a/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/RockTheVote/ImportRockTheVoteRecordTest.php
@@ -13,6 +13,31 @@ use DoSomething\Gateway\Resources\NorthstarUser;
 class ImportRockTheVoteRecordTest extends TestCase
 {
     /**
+     * Test that record is skipped if the RTV data is invalid.
+     *
+     * @return void
+     */
+    public function testSkipsImportIfInvalidRecordData()
+    {
+        $row = $this->faker->rockTheVoteReportRow([
+            RockTheVoteRecord::$startedRegistrationFieldName => '555-555-5555',
+        ]);
+        $importFile = factory(ImportFile::class)->create();
+
+        $this->northstarMock->shouldNotReceive('getUser');
+        $this->northstarMock->shouldNotReceive('createUser');
+        $this->rogueMock->shouldNotReceive('getPost');
+        $this->rogueMock->shouldNotReceive('createPost');
+
+        ImportRockTheVoteRecord::dispatch($row, $importFile);
+
+        $this->assertDatabaseHas('import_files', [
+            'id' => $importFile->id,
+            'skip_count' => 1,
+        ]);
+    }
+
+    /**
      * Test that user and post are created if user not found.
      *
      * @return void

--- a/tests/Unit/RockTheVoteRecordTest.php
+++ b/tests/Unit/RockTheVoteRecordTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use Tests\TestCase;
 use Chompy\ImportType;
 use Chompy\RockTheVoteRecord;
+use Illuminate\Validation\ValidationException;
 
 class RockTheVoteRecordTest extends TestCase
 {
@@ -280,5 +281,29 @@ class RockTheVoteRecordTest extends TestCase
         foreach (config('import.rock_the_vote.post.details') as $key) {
             $this->assertEquals($result[$key], $row[$key]);
         }
+    }
+
+    /**
+     * @return void
+     */
+    public function testMissingStartedRegisration()
+    {
+        $this->expectException(ValidationException::class);
+
+        $record = new RockTheVoteRecord($this->faker->rockTheVoteReportRow([
+            RockTheVoteRecord::$startedRegistrationFieldName => null,
+        ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testInvalidStartedRegisration()
+    {
+        $this->expectException(ValidationException::class);
+
+        $record = new RockTheVoteRecord($this->faker->rockTheVoteReportRow([
+            RockTheVoteRecord::$startedRegistrationFieldName => '555-555-5555',
+        ]));
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a check to only import a RTV record if its `Started registration` value is a date.

### How should this be reviewed?

👀 

### Any background context you want to provide?

A great follow-up cleanup task would be to use this as the groundwork for better validation of the `Phone number` field before we import it. We use a very basic [helper](https://github.com/DoSomething/chompy/blob/4e253ddcb2b1f6056468c5e64b50490d57b253f8/app/helpers.php#L50)... but it still doesn't catch [all variations](https://dosomething.slack.com/archives/CTVPG6L4R/p1603215583087800?thread_ts=1603215534.087600&cid=CTVPG6L4R)

### Relevant tickets

References [Pivotal #175256802](https://www.pivotaltracker.com/story/show/175256802).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
