### PR TITLE
Adds link to QA RTV

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Third-parties with authorized access can post data to the Chompy API. See [API d
 
 Chompy supports imports of two types of CSV:
 
-- [Rock The Vote voter registrations](https://github.com/DoSomething/chompy/tree/master/docs/imports.md#rock-the-vote)
+- [Rock The Vote voter registrations](https://github.com/DoSomething/chompy/tree/master/docs/imports#rock-the-vote)
 
 - Email subscriptions to newsletters
 

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -2,6 +2,10 @@
 
 Chompy integrates with the Rock The Vote (RTV) API to generate, download, and import voter registration CSV's on an hourly basis.
 
+QA: https://staging.rocky.rockthevote.com/registrants/new?partner=26299
+
+Production: https://register.rockthevote.com/registrants/new?partner=37187
+
 ## Overview
 
 The import upserts a `voter-reg` type post for each unique "Started registration" datetime we receive for a user -- saving it to an action we set via config variable. This import action is changed each election year, in order to track user registrations per election.


### PR DESCRIPTION
### What's this PR do?

This pull request adds a link to our QA Rock The Vote instance. I've updated the env variables in Heroku for `dosomething-chompy-qa` with our QA specific partner ID, API key, and API URL.

Also fixes a link to the RTV import documentation.

### How should this be reviewed?

👀 

### Any background context you want to provide?

💐 

### Relevant tickets

References [Pivotal #175368597](https://www.pivotaltracker.com/story/show/175368597).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
