### PR TITLE
Bug hunt

### DIFF
--- a/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
+++ b/app/Jobs/RockTheVote/ImportRockTheVoteRecord.php
@@ -249,11 +249,17 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     public function getPost(NorthstarUser $user)
     {
-        $result = app(Rogue::class)->getPosts([
+        $params = [
             'action_id' => $this->postData['action_id'],
             'northstar_id' => $user->id,
             'type' => config('import.rock_the_vote.post.type'),
-        ]);
+        ];
+
+        logger('getPost params', $params);
+
+        $result = app(Rogue::class)->getPosts($params);
+
+        logger('getPost response', $result);
 
         if (! $result['data']) {
             return null;
@@ -288,11 +294,17 @@ class ImportRockTheVoteRecord implements ShouldQueue
      */
     private function createPost($user)
     {
-        $post = app(Rogue::class)->createPost(array_merge([
+        $params = array_merge([
             'northstar_id' => $user->id,
-        ], $this->postData));
+        ], $this->postData);
+
+        logger('createPost params', $params);
+
+        $post = app(Rogue::class)->createPost($params);
 
         info('Created post', ['post' => $post['data']['id'], 'user' => $user->id]);
+
+        logger('createPost response', $post);
 
         return $post['data'];
     }


### PR DESCRIPTION
### What's this PR do?

This pull request adds debugging to start digging into why the RTV backfill created new `voter-reg` posts instead of updating existing posts (see [Slack thread](https://dosomething.slack.com/archives/C03T8SDJG/p1611686162004200?thread_ts=1611599024.000600&cid=C03T8SDJG)). It doesn't fix any bugs.

### How should this be reviewed?

👀 

### Any background context you want to provide?


Testing locally, we can see that the `details` property is no longer returned in a Rogue `GET /posts` index query, which would explain the bug. We inspect the `details` property to find the saved `Started registration` key/value to determine whether to create a new `voter-reg` post or update an existing one.

As an example, you'll find there's no `details` property in the debugging of the `getPost` response:

```
[2021-01-27 04:29:53] local.DEBUG: getPost params {"action_id":"11","northstar_id":"6010e1930f5e02517c440c18","type":"voter-reg"} 
[2021-01-27 04:29:54] local.DEBUG: getPost results {"data":[{"id":7680,"signup_id":6474,"type":"voter-reg","action":"Omnis Praesentium Alias","action_id":11,"campaign_id":"11060","media":{"url":null,"original_image_url":null,"text":null},"quantity":null,"hours_spent":null,"reactions":{"reacted":false,"total":0},"status":"step-4","location":null,"location_name":null,"created_at":"2021-01-27T04:28:42+00:00","updated_at":"2021-01-27T04:28:42+00:00","cursor":"NzY4MC4yMDIxLTAxLTI3IDA0OjI4OjQy","northstar_id":"6010e1930f5e02517c440c18","action_details":{"data":{"id":11,"name":"Omnis Praesentium Alias","campaign_id":11060,"post_type":"voter-reg","post_label":"Voter Registration","action_type":"sign-petition","action_label":"Sign a Petition","time_commitment":"<0.5","time_commitment_label":"< 30 minutes","callpower_campaign_id":null,"reportback":true,"civic_action":true,"scholarship_entry":true,"collect_school_id":true,"volunteer_credit":false,"anonymous":false,"online":false,"quiz":false,"noun":"things","verb":"done","created_at":"2020-08-28T14:46:01+00:00","updated_at":"2021-01-27T04:27:15+00:00"}}}],"meta":{"cursor":{"current":1,"prev":null,"next":null,"count":1}}} 
```

The details don't show up in the API response when creating a post, either.

```
[2021-01-27 04:29:54] local.DEBUG: createPost params {"northstar_id":"6010e1930f5e02517c440c18","source":"rock-the-vote","source_details":null,"details":"{\"Tracking Source\":\"source:email,source_details:newsletter_bdaytrigger\",\"Started registration\":\"1\\/23\\/20 20:22\",\"Finish with State\":\"No\",\"Status\":\"Complete\",\"Pre-Registered\":\"No\",\"Home zip code\":\"89032\"}","status":"register-form","type":"voter-reg","action_id":"11","group_id":null,"referrer_user_id":null} 
[2021-01-27 04:29:56] local.INFO: Created post {"post":7681,"user":"6010e1930f5e02517c440c18"} 
[2021-01-27 04:29:56] local.DEBUG: createPost response {"data":{"id":7681,"signup_id":6474,"type":"voter-reg","action":"Omnis Praesentium Alias","action_id":"11","campaign_id":"11060","media":{"url":null,"original_image_url":null,"text":null},"quantity":null,"hours_spent":null,"reactions":{"reacted":false,"total":null},"status":"register-form","location":null,"location_name":null,"created_at":"2021-01-27T04:29:54+00:00","updated_at":"2021-01-27T04:29:54+00:00","cursor":"NzY4MQ==","northstar_id":"6010e1930f5e02517c440c18","action_details":{"data":{"id":11,"name":"Omnis Praesentium Alias","campaign_id":11060,"post_type":"voter-reg","post_label":"Voter Registration","action_type":"sign-petition","action_label":"Sign a Petition","time_commitment":"<0.5","time_commitment_label":"< 30 minutes","callpower_campaign_id":null,"reportback":true,"civic_action":true,"scholarship_entry":true,"collect_school_id":true,"volunteer_credit":false,"anonymous":false,"online":false,"quiz":false,"noun":"things","verb":"done","created_at":"2020-08-28T14:46:01+00:00","updated_at":"2021-01-27T04:27:15+00:00"}},"signup":{"data":{"id":6474,"northstar_id":"6010e1930f5e02517c440c18","campaign_id":"11060","campaign_run_id":null,"quantity":0,"created_at":"2021-01-27T03:44:20+00:00","updated_at":"2021-01-27T04:28:42+00:00","cursor":"NjQ3NA==","user":{"data":{"id":"6010e1930f5e02517c440c18","display_name":null,"first_name":null,"last_initial":"","photo":null,"voting_method":null,"voting_plan_method_of_transport":null,"voting_plan_time_of_day":null,"voting_plan_attending_with":null,"language":null,"country":null,"sms_status":null,"sms_paused":false,"sms_subscription_topics":null,"email_subscription_topics":["community"],"role":"user","updated_at":"2021-01-27T04:29:52+00:00","created_at":"2021-01-27T03:44:19+00:00"}}}}}} 
```
I checked in the database, and the post.details do get saved correctly:

<img width="747" alt="Screen Shot 2021-01-27 at 4 02 40 AM" src="https://user-images.githubusercontent.com/1236811/105988490-8cc25f00-6054-11eb-9684-aefe6d2026e2.png">

This also feels like a very similar bug (seemingly from Rogue) to why Gambit is no longer finding a `why_participated` property in a `GET /signups` index query on Rogue -- prompting us to collect it from the user on every photo post (it should only happen for the member's first) -- see [Slack thread](https://dosomething.slack.com/archives/CUQMU4Q6B/p1610497494009900)  

cc @DFurnes @weerd 


### Relevant tickets

References [Pivotal #176667386](https://www.pivotaltracker.com/n/projects/2328687/stories/176667386).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.