### PR TITLE
Adds job to mute promotions via CSV

### DIFF
--- a/app/ImportType.php
+++ b/app/ImportType.php
@@ -12,6 +12,13 @@ class ImportType
     public static $emailSubscription = 'email-subscription';
 
     /**
+     * A mute promotions import.
+     *
+     * @var string
+     */
+    public static $mutePromotions = 'mute-promotions';
+
+    /**
      * A Rock The Vote import.
      *
      * @var string

--- a/app/Jobs/ImportFileRecords.php
+++ b/app/Jobs/ImportFileRecords.php
@@ -54,8 +54,12 @@ class ImportFileRecords implements ShouldQueue
      * @param array $importOptions
      * @return void
      */
-    public function __construct(\Chompy\User $user = null, string $filepath, string $importType, array $importOptions = [])
-    {
+    public function __construct(
+        \Chompy\User $user = null,
+        string $filepath,
+        string $importType,
+        array $importOptions = []
+    ) {
         $this->filepath = $filepath;
         $this->importType = $importType;
         $this->importOptions = $importOptions;
@@ -105,11 +109,20 @@ class ImportFileRecords implements ShouldQueue
         $importFile->save();
 
         foreach ($records as $offset => $record) {
-            if ($this->importType === ImportType::$rockTheVote) {
-                ImportRockTheVoteRecord::dispatch($record, $importFile);
-            } elseif ($this->importType === ImportType::$emailSubscription) {
-                ImportEmailSubscription::dispatch($record, $importFile, $this->importOptions);
+            switch ($this->importType) {
+                case ImportType::$rockTheVote:
+                    ImportRockTheVoteRecord::dispatch($record, $importFile);
+                    break;
+
+                case ImportType::$emailSubscription:
+                    ImportEmailSubscription::dispatch($record, $importFile, $this->importOptions);
+                    break;
+
+                case ImportType::$mutePromotions:
+                    ImportMutePromotions::dispatch($record, $importFile);
+                    break;
             }
+
             event(new LogProgress('', 'progress', ($offset / $this->totalRecords) * 100));
         }
 

--- a/app/Jobs/MutePromotions/ImportMutePromotions.php
+++ b/app/Jobs/MutePromotions/ImportMutePromotions.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Chompy\Jobs;
+
+use Carbon\Carbon;
+use Chompy\Models\ImportFile;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class ImportMutePromotions implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    /**
+     * The Northstar user ID to mute promotions for.
+     *
+     * @var string
+     */
+    protected $userId;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param array $record
+     * @param ImportFile $importFile
+     * @return void
+     */
+    public function __construct($record, ImportFile $importFile)
+    {
+        $this->userId = $record['northstar_id'];
+        $this->importFile = $importFile;
+    }
+
+    /**
+     * Execute the job to set user's promotions_muted_at field.
+     *
+     * @return array
+     */
+    public function handle()
+    {
+        $user = gateway('northstar')->asClient()->updateUser($this->userId, [
+            'promotions_muted_at' => Carbon::now(),
+        ]);
+
+        info('import.mute-promotions', ['promotions_muted_at' => $user->promotions_muted_at, 'user_id' => $this->userId]);
+
+        $this->importFile->incrementImportCount();
+    }
+}

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -32,6 +32,13 @@
                             Email subscription
                         </a>
                     </li>
+
+                    <li @if (Request::path() === "import/mute-promotions") class="active" @endif>
+                        <a class="nav-item nav-link" href="/import/mute-promotions">
+                            Mute promotions
+                        </a>
+                    </li>
+
                     <li @if (strpos(Request::path(), 'rock-the-vote') !== false)) class="active" @endif>
                         <a class="nav-item nav-link" href="/rock-the-vote-reports">
                             Rock The Vote

--- a/resources/views/pages/import-files/create.blade.php
+++ b/resources/views/pages/import-files/create.blade.php
@@ -12,6 +12,8 @@
             @include('pages.partials.rock-the-vote.create', ['config' => $config])
         @elseif ($importType === \Chompy\ImportType::$emailSubscription)
             @include('pages.partials.email-subscription.create')
+        @elseif ($importType === \Chompy\ImportType::$mutePromotions)
+            @include('pages.partials.mute-promotions.create')
         @endif
         <div class="form-group">
             <h3>Upload</h3>

--- a/resources/views/pages/partials/mute-promotions/create.blade.php
+++ b/resources/views/pages/partials/mute-promotions/create.blade.php
@@ -1,0 +1,13 @@
+<div class="form-group">
+    <h1>Mute promotions</h1>
+
+    <p class="lead">
+        Updates users in CSV to set a value for the <code>promotions_muted_at</code> field, triggering their Customer.io profile deletion.
+    </p>
+
+    <p>Columns:</p>
+
+    <ul>
+        <li><code>northstar_id</code> - required</li>
+    </ul>
+</div>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new file import type, `mute-promotions`, that sets the `promotions_muted_at` field for the users in a given CSV, deleting their Customer.io profile.

<img width="500" alt="Mute Promotions Import screenshot" src="https://user-images.githubusercontent.com/1236811/108776601-786c6780-7517-11eb-8991-81e6e09d06c0.png">


### How should this be reviewed?

👀 

### Any background context you want to provide?

🍥 

### Relevant tickets

References [Pivotal #176771195](https://www.pivotaltracker.com/story/show/176771195).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
