### PR TITLE
Adds log table for mute promotions import

### DIFF
--- a/app/Http/Controllers/Web/FailedJobController.php
+++ b/app/Http/Controllers/Web/FailedJobController.php
@@ -32,7 +32,12 @@ class FailedJobController extends Controller
         $failedJob->commandName = $json->data->commandName;
         $failedJob->errorMessage = Str::limit($failedJob->exception, 255);
 
-        if (Str::contains($failedJob->commandName, 'CallPower') || Str::contains($failedJob->commandName, 'SoftEdge') || Str::contains($failedJob->commandName, 'RockTheVote')) {
+        if (
+            Str::contains($failedJob->commandName, 'CallPower') ||
+            Str::contains($failedJob->commandName, 'SoftEdge') ||
+            Str::contains($failedJob->commandName, 'RockTheVote') ||
+            Str::contains($failedJob->commandName, 'MutePromotions')
+        ) {
             $command = unserialize($json->data->command);
             $failedJob->parameters = $command->getParameters();
         }

--- a/app/Http/Controllers/Web/ImportFileController.php
+++ b/app/Http/Controllers/Web/ImportFileController.php
@@ -96,9 +96,11 @@ class ImportFileController extends Controller
 
         $request->validate($rules);
 
-        // Push file to S3.
         $upload = $request->file('upload-file');
+        // Save original file name to reference from admin UI.
+        $importOptions['name'] = $upload->getClientOriginalName();
 
+        // Push file to S3.
         $path = 'uploads/' . $importType . '-importer' . Carbon::now() . '.csv';
         $csv = Reader::createFromPath($upload->getRealPath());
         $success = Storage::put($path, (string) $csv);

--- a/app/Http/Controllers/Web/ImportFileController.php
+++ b/app/Http/Controllers/Web/ImportFileController.php
@@ -7,6 +7,7 @@ use Chompy\ImportType;
 use League\Csv\Reader;
 use Illuminate\Http\Request;
 use Chompy\Models\ImportFile;
+use Chompy\Models\MutePromotionsLog;
 use Chompy\Models\RockTheVoteLog;
 use Chompy\Jobs\ImportFileRecords;
 use Chompy\Http\Controllers\Controller;
@@ -134,11 +135,20 @@ class ImportFileController extends Controller
         $importFile = ImportFile::findOrFail($id);
         $rows = [];
 
-        if ($importFile->import_type === ImportType::$rockTheVote) {
-            $rows = RockTheVoteLog::where('import_file_id', $id)->paginate(15);
+        switch ($importFile->import_type) {
+            case ImportType::$mutePromotions:
+                $rows = MutePromotionsLog::where('import_file_id', $id)->paginate(100);
+                break;
+
+            case ImportType::$rockTheVote:
+                $rows = RockTheVoteLog::where('import_file_id', $id)->paginate(15);
+                break;
         }
 
-        return view('pages.import-files.show', ['importFile' => $importFile, 'rows' => $rows]);
+        return view('pages.import-files.show', [
+            'importFile' => $importFile,
+            'rows' => $rows,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -2,6 +2,7 @@
 
 namespace Chompy\Http\Controllers\Web;
 
+use Chompy\Models\MutePromotionsLog;
 use Chompy\Models\RockTheVoteLog;
 use Chompy\Http\Controllers\Controller;
 
@@ -25,8 +26,10 @@ class UserController extends Controller
      */
     public function show($id)
     {
-        $rows = RockTheVoteLog::where('user_id', $id)->paginate(15);
-
-        return view('pages.users.show', ['id' => $id, 'rows' => $rows]);
+        return view('pages.users.show', [
+            'id' => $id,
+            'mutePromotionsLogs' => MutePromotionsLog::where('user_id', $id)->get(),
+            'rockTheVoteLogs' => RockTheVoteLog::where('user_id', $id)->paginate(15),
+        ]);
     }
 }

--- a/app/Jobs/MutePromotions/ImportMutePromotions.php
+++ b/app/Jobs/MutePromotions/ImportMutePromotions.php
@@ -4,6 +4,7 @@ namespace Chompy\Jobs;
 
 use Carbon\Carbon;
 use Chompy\Models\ImportFile;
+use Chompy\Models\MutePromotionsLog;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -42,6 +43,11 @@ class ImportMutePromotions implements ShouldQueue
     {
         $user = gateway('northstar')->asClient()->updateUser($this->userId, [
             'promotions_muted_at' => Carbon::now(),
+        ]);
+
+        MutePromotionsLog::create([
+            'import_file_id' => $this->importFile->id,
+            'user_id' => $this->userId,
         ]);
 
         info('import.mute-promotions', ['promotions_muted_at' => $user->promotions_muted_at, 'user_id' => $this->userId]);

--- a/app/Jobs/MutePromotions/ImportMutePromotions.php
+++ b/app/Jobs/MutePromotions/ImportMutePromotions.php
@@ -54,4 +54,17 @@ class ImportMutePromotions implements ShouldQueue
 
         $this->importFile->incrementImportCount();
     }
+
+    /**
+     * Return the parameters passed to this job.
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return [
+            'import_file_id' => $this->importFile->id,
+            'user_id' => $this->userId,
+        ];
+    }
 }

--- a/app/Models/MutePromotionsLog.php
+++ b/app/Models/MutePromotionsLog.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Chompy\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MutePromotionsLog extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'import_file_id',
+        'user_id',
+    ];
+
+    /**
+     * Attributes that can be queried when filtering.
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * any of these are actual indexes on the database... but they should be!
+     *
+     * @var array
+     */
+    public static $indexes = [
+        'import_file_id',
+        'user_id',
+    ];
+}

--- a/database/migrations/2021_02_22_000000_create_mute_promotions_logs_table.php
+++ b/database/migrations/2021_02_22_000000_create_mute_promotions_logs_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateMutePromotionsLogsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('mute_promotions_logs', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('import_file_id')->index();
+            $table->string('user_id')->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('mute_promotions_logs');
+    }
+}

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -183,6 +183,10 @@ If the RTV Status is past Step 1, we also include these fields when creating a n
 
 - Before we partnered with Rock The Vote on voter registration, we had partnered with TurboVote in 2016, 2018. See [VR Tech Inventory](https://docs.google.com/document/d/1xs2C3DNdD5h1j_abBrGVBNrsrxKvwn2VHDWweIEhvqc/edit?usp=sharing) for more details.
 
+# Mute Promotions
+
+Admins can upload CSV's of user IDs to delete their Customer.io profiles. The import will update each user's `promotions_muted_at` field via the Northstar API, triggering their Customer.io profile deletion.
+
 # Email Subscriptions
 
 Admins can upload CSV's of Instapage leads to subscribe users to email newsletters. The import will create or update an existing user via the Northstar API.

--- a/resources/views/pages/import-files/show.blade.php
+++ b/resources/views/pages/import-files/show.blade.php
@@ -17,7 +17,10 @@
     <p>
         This file had a total of {{$importFile->row_count}} rows: <strong>{{$importFile->import_count}} imported, {{$importFile->skip_count}} skipped</strong>.
     </p>
-    @if ($importFile->import_type === \Chompy\ImportType::$rockTheVote)
+
+    @if ($importFile->import_type === \Chompy\ImportType::$mutePromotions)
+        @include('pages.partials.mute-promotions.logs', ['rows' => $rows, 'user_id' => null])
+    @elseif ($importFile->import_type === \Chompy\ImportType::$rockTheVote)
         @include('pages.partials.rock-the-vote.logs', ['rows' => $rows, 'user_id' => null])
     @endif
 </div>

--- a/resources/views/pages/partials/mute-promotions/logs.blade.php
+++ b/resources/views/pages/partials/mute-promotions/logs.blade.php
@@ -1,0 +1,17 @@
+<table class="table">
+    <thead>
+        <tr class="row">
+            <th>{{$user_id ? 'Import File' : 'User'}}</th>
+        </tr>
+    </thead>
+
+    @foreach($rows as $key => $row)
+        <tr class="row">
+            <td>
+                <a href="{{$user_id ? '/import-files/' . $row->import_file_id : '/users/' . $row->user_id}}">
+                    {{$user_id ? $row->import_file_id : $row->user_id}}
+                </a>
+            </td> 
+        </tr>
+    @endforeach
+</table>

--- a/resources/views/pages/users/show.blade.php
+++ b/resources/views/pages/users/show.blade.php
@@ -4,11 +4,16 @@
 
 <div>
     <h1>{{$id}}</h1>
+
     <p>
         <a href="{{config('services.rogue.url') . '/users/' . $id}}">View user in Rogue</a>
     </p>
-    <h3>Rock The Vote</h3>
-    @include('pages.partials.rock-the-vote.logs', ['user_id' => $id, 'rows' => $rows])
+
+    <h3>Mute Promotions Imports</h3>
+    @include('pages.partials.mute-promotions.logs', ['user_id' => $id, 'rows' => $mutePromotionsLogs])
+
+    <h3>Rock The Vote Imports</h3>
+    @include('pages.partials.rock-the-vote.logs', ['user_id' => $id, 'rows' => $rockTheVoteLogs])
 </div>
 
 @stop


### PR DESCRIPTION
### What's this PR do?

This pull request continues work done in #200 to add a `MutePromotionsLog` model, which may help troubleshoot any imports we run once we go live (storing each imported user in a DB table vs needing to query Papertrail logs).

It also stores the original uploaded file name into the `options` serialized field, to make it easier to keep track of which of the [10 CSV's](https://trello.com/c/8P4yy1Ys/1734-csvs-w-profiles-to-remove-from-customerio) have been uploaded for import so far.

### How should this be reviewed?

Import File view:

<img width="500" src="https://user-images.githubusercontent.com/1236811/108800280-8803a480-7547-11eb-8472-0470d4c7a770.png">


User view:

<img width="500" src="https://user-images.githubusercontent.com/1236811/108784390-27af3b80-7524-11eb-99bb-f9ee40f4ec06.png">


### Any background context you want to provide?

We discussed in the [Pivotal thread](https://www.pivotaltracker.com/n/projects/2328687/stories/176771195/comments/222168919) that we're not too worried about storage implications this may have for now (we'll be running this import for millions of users this week).

### Relevant tickets

References [Pivotal #176771195](https://www.pivotaltracker.com/story/show/176771195).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
