### PR TITLE
Use new Northstar endpoint to mute promotions

### DIFF
--- a/app/Http/Controllers/Web/ImportFileController.php
+++ b/app/Http/Controllers/Web/ImportFileController.php
@@ -139,7 +139,7 @@ class ImportFileController extends Controller
 
         switch ($importFile->import_type) {
             case ImportType::$mutePromotions:
-                $rows = MutePromotionsLog::where('import_file_id', $id)->paginate(100);
+                $rows = MutePromotionsLog::where('import_file_id', $id)->paginate(25);
                 break;
 
             case ImportType::$rockTheVote:

--- a/app/Http/Controllers/Web/ImportFileController.php
+++ b/app/Http/Controllers/Web/ImportFileController.php
@@ -139,7 +139,7 @@ class ImportFileController extends Controller
 
         switch ($importFile->import_type) {
             case ImportType::$mutePromotions:
-                $rows = MutePromotionsLog::where('import_file_id', $id)->paginate(25);
+                $rows = MutePromotionsLog::where('import_file_id', $id)->paginate(100);
                 break;
 
             case ImportType::$rockTheVote:

--- a/app/Jobs/MutePromotions/ImportMutePromotions.php
+++ b/app/Jobs/MutePromotions/ImportMutePromotions.php
@@ -2,7 +2,6 @@
 
 namespace Chompy\Jobs;
 
-use Carbon\Carbon;
 use Chompy\Models\ImportFile;
 use Chompy\Models\MutePromotionsLog;
 use Illuminate\Bus\Queueable;

--- a/app/Jobs/MutePromotions/ImportMutePromotions.php
+++ b/app/Jobs/MutePromotions/ImportMutePromotions.php
@@ -39,13 +39,13 @@ class ImportMutePromotions implements ShouldQueue
      */
     public function handle()
     {
-        /**
+        /*
          * We're sending a POST request instead of DELETE because Gateway PHP doesn't properly
          * parse a Northstar DELETE request.
          */
         $response = gateway('northstar')->asClient()->post('v2/users/'. $this->userId . '/promotions');
 
-        if (!$response) {
+        if (! $response) {
             throw new Exception('Could not mute promotions for user ' . $this->userId);
         }
 

--- a/app/Jobs/MutePromotions/ImportMutePromotions.php
+++ b/app/Jobs/MutePromotions/ImportMutePromotions.php
@@ -35,22 +35,18 @@ class ImportMutePromotions implements ShouldQueue
     }
 
     /**
-     * Execute the job to set user's promotions_muted_at field.
-     *
-     * @return array
+     * Execute the job to mute user promotions.
      */
     public function handle()
     {
-        $user = gateway('northstar')->asClient()->updateUser($this->userId, [
-            'promotions_muted_at' => Carbon::now(),
-        ]);
+        gateway('northstar')->asClient()->delete('v2/users/'. $this->userId . '/promotions');
 
         MutePromotionsLog::create([
             'import_file_id' => $this->importFile->id,
             'user_id' => $this->userId,
         ]);
 
-        info('import.mute-promotions', ['promotions_muted_at' => $user->promotions_muted_at, 'user_id' => $this->userId]);
+        info('import.mute-promotions', ['user_id' => $this->userId]);
 
         $this->importFile->incrementImportCount();
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,13 @@ Third-parties with authorized access can post data to the Chompy API. See [API d
 
 ## CSV
 
-Chompy supports imports of two types of CSV:
+Chompy supports imports of three types of CSV:
 
 - [Rock The Vote voter registrations](https://github.com/DoSomething/chompy/tree/master/docs/imports#rock-the-vote)
 
-- Email subscriptions to newsletters
+- [Email subscriptions](https://github.com/DoSomething/chompy/tree/master/docs/imports#email-subscriptions) to newsletters
+
+- [Mute promotions](https://github.com/DoSomething/chompy/tree/master/docs/imports#mute-promotions) for deleting Customer.io profiles
 
 Staff members may login to Chompy with their Northstar credentials, and select a CSV to import. The uploaded file is stored on S3, and then a [queue job](https://laravel.com/docs/5.6/queues) is pushed onto a Redis queue to import records from the CSV as users and/or activity.
 

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -185,7 +185,7 @@ If the RTV Status is past Step 1, we also include these fields when creating a n
 
 # Mute Promotions
 
-Admins can upload CSV's of user IDs to delete their Customer.io profiles. The import will update each user's `promotions_muted_at` field via the Northstar API, triggering their Customer.io profile deletion.
+Admins can upload CSV's of user IDs to delete their Customer.io profiles. The import will execute a Northstar API request to mute promotions for each user, setting their `promotions_muted_at` field and triggering their Customer.io profile deletion.
 
 # Email Subscriptions
 

--- a/docs/imports/README.md
+++ b/docs/imports/README.md
@@ -185,7 +185,7 @@ If the RTV Status is past Step 1, we also include these fields when creating a n
 
 # Mute Promotions
 
-Admins can upload CSV's of user IDs to delete their Customer.io profiles. The import will execute a Northstar API request to mute promotions for each user, setting their `promotions_muted_at` field and triggering their Customer.io profile deletion.
+Admins can upload CSV's of user IDs to delete their Customer.io profiles. The import will execute a Northstar API request for each user to set their `promotions_muted_at` field and trigger their Customer.io profile deletion.
 
 # Email Subscriptions
 

--- a/resources/views/pages/partials/mute-promotions/logs.blade.php
+++ b/resources/views/pages/partials/mute-promotions/logs.blade.php
@@ -15,3 +15,5 @@
         </tr>
     @endforeach
 </table>
+
+{{$rows->links()}}

--- a/tests/Jobs/MutePromotions/ImportMutePromotionsTest.php
+++ b/tests/Jobs/MutePromotions/ImportMutePromotionsTest.php
@@ -9,7 +9,7 @@ use Chompy\Jobs\ImportMutePromotions;
 class ImportMutePromotionsTest extends TestCase
 {
     /**
-     * Test that Northstar DELETE /users/:id/promotions request is executed.
+     * Test that Northstar Mute Promotions request is executed and logged.
      *
      * @return void
      */

--- a/tests/Jobs/MutePromotions/ImportMutePromotionsTest.php
+++ b/tests/Jobs/MutePromotions/ImportMutePromotionsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Jobs\RockTheVote;
+
+use Tests\TestCase;
+use Chompy\Models\ImportFile;
+use Chompy\Jobs\ImportMutePromotions;
+
+class ImportMutePromotionsTest extends TestCase
+{
+    /**
+     * Test that Northstar DELETE /users/:id/promotions request is executed.
+     *
+     * @return void
+     */
+    public function testExecutesMutePromotionsNorthstarRequest()
+    {
+        $userId = $this->faker->northstar_id;
+        $importFile = factory(ImportFile::class)->create();
+
+        $this->northstarMock->shouldReceive('delete')->with('v2/users/' . $userId . '/promotions');
+
+        $job = new ImportMutePromotions(
+            ['northstar_id' => $userId],
+            $importFile
+        );
+        $job->handle();
+
+        $this->assertDatabaseHas('mute_promotions_logs', [
+            'import_file_id' => $importFile->id,
+            'user_id' => $userId,
+        ]);
+    }
+}

--- a/tests/Jobs/MutePromotions/ImportMutePromotionsTest.php
+++ b/tests/Jobs/MutePromotions/ImportMutePromotionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Jobs\RockTheVote;
 
+use Exception;
 use Tests\TestCase;
 use Chompy\Models\ImportFile;
 use Chompy\Jobs\ImportMutePromotions;
@@ -18,7 +19,12 @@ class ImportMutePromotionsTest extends TestCase
         $userId = $this->faker->northstar_id;
         $importFile = factory(ImportFile::class)->create();
 
-        $this->northstarMock->shouldReceive('delete')->with('v2/users/' . $userId . '/promotions');
+        $this->northstarMock->shouldReceive('post')
+            ->with('v2/users/' . $userId . '/promotions')
+            ->andReturn(['data' => [
+                'id' => $userId,
+                'promotions_muted_at' => now(),
+            ]]);
 
         $job = new ImportMutePromotions(
             ['northstar_id' => $userId],
@@ -27,6 +33,35 @@ class ImportMutePromotionsTest extends TestCase
         $job->handle();
 
         $this->assertDatabaseHas('mute_promotions_logs', [
+            'import_file_id' => $importFile->id,
+            'user_id' => $userId,
+        ]);
+    }
+
+    /**
+     * Test that an error is thrown if the Northstar API request fails.
+     *
+     * @return void
+     */
+    public function testDoesNotLogMutePermissionsIfUserNotFound()
+    {
+        $userId = $this->faker->northstar_id;
+        $importFile = factory(ImportFile::class)->create();
+
+        // Gateway PHP returns a null value when resource not found.
+        $this->northstarMock->shouldReceive('post')
+            ->with('v2/users/' . $userId . '/promotions')
+            ->andReturn(null);
+
+        $this->expectException(Exception::class);
+
+        $job = new ImportMutePromotions(
+            ['northstar_id' => $userId],
+            $importFile
+        );
+        $job->handle();
+
+        $this->assertDatabaseMissing('mute_promotions_logs', [
             'import_file_id' => $importFile->id,
             'user_id' => $userId,
         ]);


### PR DESCRIPTION
### What's this PR do?

This pull request alters the `ImportMutePromotions` job to execute a Northstar API request to the new `POST /users/:userId/promotions` endpoint added in https://github.com/DoSomething/northstar/pull/1132, instead of `PUT /users/:userId`.

This allows us to successfully set the `promotions_muted_at` field for users who may have existing null `email` and `mobile` field values (e.g. GDPR users).

### How should this be reviewed?

👀 

### Any background context you want to provide?

🌵 

### Relevant tickets

References [Pivotal #176771195](https://www.pivotaltracker.com/story/show/176771195).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
