### PR TITLE
Filter import files by type

### DIFF
--- a/app/Http/Controllers/Web/ImportFileController.php
+++ b/app/Http/Controllers/Web/ImportFileController.php
@@ -131,7 +131,9 @@ class ImportFileController extends Controller
             $query->where('import_type', $importType);
         }
 
-        return view('pages.import-files.index', ['data' => $query->paginate(15)]);
+        return view('pages.import-files.index', [
+            'data' => $query->paginate(15)->appends(request()->query()),
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Web/ImportFileController.php
+++ b/app/Http/Controllers/Web/ImportFileController.php
@@ -118,13 +118,20 @@ class ImportFileController extends Controller
     /**
      * Display a listing of import files.
      *
+     * @param Request $request
      * @return Response
      */
-    public function index()
+    public function index(Request $request)
     {
-        $data = ImportFile::orderBy('id', 'desc')->paginate(15);
+        $importType = $request->query('type');
 
-        return view('pages.import-files.index', ['data' => $data]);
+        $query = ImportFile::orderBy('id', 'desc');
+
+        if ($importType) {
+            $query->where('import_type', $importType);
+        }
+
+        return view('pages.import-files.index', ['data' => $query->paginate(15)]);
     }
 
     /**

--- a/app/Jobs/MutePromotions/ImportMutePromotions.php
+++ b/app/Jobs/MutePromotions/ImportMutePromotions.php
@@ -15,6 +15,14 @@ class ImportMutePromotions implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable;
 
     /**
+     * The number of seconds the job can run before timing out.
+     * We set this to 12 minutes because each of these files is about 490K rows, and will time out.
+     *
+     * @var int
+     */
+    public $timeout = 720;
+
+    /**
      * The Northstar user ID to mute promotions for.
      *
      * @var string

--- a/resources/views/pages/import-files/index.blade.php
+++ b/resources/views/pages/import-files/index.blade.php
@@ -14,6 +14,7 @@
             <th class="col-md-3">Created by</th>
           </tr>
         </thead>
+
         @foreach($data as $key => $importFile)
             <tr class="row">
               <td class="col-md-3">
@@ -21,22 +22,27 @@
                   <strong>{{$importFile->created_at}}</strong>
                 </a>
               </td>
+
               <td class="col-md-3">
                 {{$importFile->import_type}}
+
                 @if ($importFile->options)
                   @include('pages.partials.import-files.import-options', ['options' => $importFile->options])
                 @endif
-              </td> 
+              </td>
+
               <td class="col-md-3">
                 {{$importFile->import_count}}
               </td>
+
               <td class="col-md-3">
                 {{$importFile->user_id ? $importFile->user_id : 'Console'}}
               </td>     
             </tr>
         @endforeach
     </table>
-    {{$data->links()}}
+
+    {{$data->appends(request()->query())->links()}}
 </div>
 
 @stop


### PR DESCRIPTION
### What's this PR do?

This pull request adds support to pass a `type` query parameter to the index view of import files, to only view a specific type of import file. e.g. `http://chompy.test/import-files?type=mute-promotions`.

For now, we need to manually enter the URL -- adding a dropdown into the UI to filter will be for another PR.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This will be helpful for debugging the Mute Promotions import by isolating all `mute-promotions` import files. We regularly create `rock-the-vote` import files each hour, which makes it difficult to get a high level view of other import types we support via CSV (`mute-promotions`, `email-subscription`) 

### Relevant tickets

References [Pivotal #176771195](https://www.pivotaltracker.com/story/show/176771195).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
