### PR TITLE
Override timeout for ImportFileRecords job

### DIFF
--- a/app/Jobs/ImportFileRecords.php
+++ b/app/Jobs/ImportFileRecords.php
@@ -18,6 +18,14 @@ class ImportFileRecords implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable;
 
     /**
+     * The number of seconds the job can run before timing out.
+     * We set this to 12 minutes to avoid timeouts with the Mute Permutations CSVs (490K rows).
+     *
+     * @var int
+     */
+    public $timeout = 720;
+
+    /**
      * The path to the stored csv.
      *
      * @var string

--- a/app/Jobs/MutePromotions/ImportMutePromotions.php
+++ b/app/Jobs/MutePromotions/ImportMutePromotions.php
@@ -15,14 +15,6 @@ class ImportMutePromotions implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable;
 
     /**
-     * The number of seconds the job can run before timing out.
-     * We set this to 12 minutes because each of these files is about 490K rows, and will time out.
-     *
-     * @var int
-     */
-    public $timeout = 720;
-
-    /**
      * The Northstar user ID to mute promotions for.
      *
      * @var string


### PR DESCRIPTION
### What's this PR do?

This pull request sets our `ImportFileRecords` timeout to 12 minutes, in hopes that we can make it through a full Mute Permutations CSV. I mistakenly added this to the wrong job in #203 

### How should this be reviewed?

👀 

### Any background context you want to provide?

🐢 

### Relevant tickets

References [Pivotal #176771195](https://www.pivotaltracker.com/story/show/176771195).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
