### PR TITLE
Fixes error on user view

### DIFF
--- a/resources/views/pages/partials/mute-promotions/logs.blade.php
+++ b/resources/views/pages/partials/mute-promotions/logs.blade.php
@@ -16,4 +16,6 @@
     @endforeach
 </table>
 
-{{$rows->links()}}
+@if(method_exists($rows, 'links'))
+    {{$rows->links()}}
+@endif


### PR DESCRIPTION
### What's this PR do?

This pull request adds a check to see whether the `links` method exists on the `$rows` variable within the Mute Promotions logs added in #201. We shouldn't be uploading too many CSV's that repeat user ID's, which is why this view shouldn't need to paginate when viewing a user. The pagination links are more likely to be used on the Rock The Vote section, which appears below the Mute Promotions logs.

This could probably be cleaned up to have different routes per import, e.g. `user/:id/:importType` but for now this will avoid the server error rendered when viewing a user (e.g. `/user/:id`)

### How should this be reviewed?

👀 

### Any background context you want to provide?

🚑 

### Relevant tickets

References [Pivotal #176771195](https://www.pivotaltracker.com/story/show/176771195).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
