### PR TITLE
Bumps ImportFileRecords job timeout to 2 hours

### DIFF
--- a/app/Jobs/ImportFileRecords.php
+++ b/app/Jobs/ImportFileRecords.php
@@ -19,11 +19,11 @@ class ImportFileRecords implements ShouldQueue
 
     /**
      * The number of seconds the job can run before timing out.
-     * We set this to 12 minutes to avoid timeouts with the Mute Permutations CSVs (490K rows).
+     * We set this to 2 hours to avoid timeouts with the Mute Permutations CSVs (490K rows).
      *
      * @var int
      */
-    public $timeout = 720;
+    public $timeout = 7200; // 60 seconds * 60 minutes * 2 hours
 
     /**
      * The path to the stored csv.


### PR DESCRIPTION
### What's this PR do?

After #206 -- we're still seeing that a second import file is created for a Mute Promotions CSV. This may be because the job didn't finish after the 12 minute timeout -- so let's try bumping it up to 2 hours.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🕥 

### Relevant tickets

References [Pivotal #177118983](https://www.pivotaltracker.com/n/projects/2328687/stories/177118983).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
