### PR TITLE
Adds CSV download for Mute Promotions failed jobs

### DIFF
--- a/app/Http/Controllers/Web/ExportController.php
+++ b/app/Http/Controllers/Web/ExportController.php
@@ -38,8 +38,12 @@ class ExportController extends Controller
      */
     public function store(Request $request)
     {
-        $exportType = $request['type'];
+        $request->validate([
+            'type' => 'required|in:MutePromotions',
+        ]);
 
+        $exportType = $request['type'];
+    
         $data = DB::table('failed_jobs')->where('payload', 'LIKE', '%'.$exportType.'%')->get();
 
         $csv = Writer::createFromFileObject(new \SplTempFileObject());

--- a/app/Http/Controllers/Web/ExportController.php
+++ b/app/Http/Controllers/Web/ExportController.php
@@ -43,7 +43,7 @@ class ExportController extends Controller
         ]);
 
         $exportType = $request['type'];
-    
+
         $data = DB::table('failed_jobs')->where('payload', 'LIKE', '%'.$exportType.'%')->get();
 
         $csv = Writer::createFromFileObject(new \SplTempFileObject());

--- a/app/Http/Controllers/Web/ExportController.php
+++ b/app/Http/Controllers/Web/ExportController.php
@@ -51,11 +51,9 @@ class ExportController extends Controller
         $csv->insertOne(['user_id']);
 
         foreach ($data as $failedJob) {
-            $json = json_decode($failedJob->payload);
-            $command = unserialize($json->data->command);
-            $parameters = $command->getParameters();
+            $data = parse_failed_job($failedJob);
 
-            $csv->insertOne([$parameters['user_id']]);
+            $csv->insertOne([$data['parameters']['user_id']]);
         }
 
         $csv->output('mute-promotions-failed-jobs.csv');

--- a/app/Http/Controllers/Web/ExportController.php
+++ b/app/Http/Controllers/Web/ExportController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Chompy\Http\Controllers\Web;
+
+use League\Csv\Writer;
+use Chompy\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class ExportController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('role:admin');
+    }
+
+    /**
+     * Display a form to create an export.
+     *
+     * @param int $id
+     * @return Response
+     */
+    public function create()
+    {
+        return view('pages.exports.create');
+    }
+
+    /**
+     * Will create a CSV to download.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function store(Request $request)
+    {
+        $exportType = $request['type'];
+
+        $data = DB::table('failed_jobs')->where('payload', 'LIKE', '%'.$exportType.'%')->get();
+
+        $csv = Writer::createFromFileObject(new \SplTempFileObject());
+
+        /**
+         * For now, we only support downloading Mute Promotions failed jobs.
+         * Hardcoding the headers as well as the values.
+         */
+        $csv->insertOne(['user_id']);
+
+        foreach ($data as $failedJob) {
+            $json = json_decode($failedJob->payload);
+            $command = unserialize($json->data->command);
+            $parameters = $command->getParameters();
+
+            $csv->insertOne([$parameters['user_id']]);
+        }
+
+        $csv->output('mute-promotions-failed-jobs.csv');
+    }
+}

--- a/app/Http/Controllers/Web/FailedJobController.php
+++ b/app/Http/Controllers/Web/FailedJobController.php
@@ -2,7 +2,6 @@
 
 namespace Chompy\Http\Controllers\Web;
 
-use Illuminate\Support\Str;
 use Chompy\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -20,8 +19,6 @@ class FailedJobController extends Controller
         $this->middleware('role:admin');
     }
 
-
-
     /**
      * Display a listing of failed jobs.
      *
@@ -29,9 +26,9 @@ class FailedJobController extends Controller
      */
     public function index()
     {
-        $data = DB::table('failed_jobs')->paginate(10);
-
-        return view('pages.failed-jobs.index', ['data' => $data]);
+        return view('pages.failed-jobs.index', [
+            'data' => DB::table('failed_jobs')->paginate(10),
+        ]);
     }
 
     /**
@@ -49,7 +46,7 @@ class FailedJobController extends Controller
         }
 
         return view('pages.failed-jobs.show', [
-            'data' => parse_failed_job($data[0]),
+            'failedJob' => parse_failed_job($data[0]),
         ]);
     }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 /**
  * Parse a string as boolean.
  *
@@ -61,4 +63,24 @@ function is_valid_mobile($mobile)
     $mobile = preg_replace("/[\s-]+/", '', $mobile);
 
     return strlen($mobile) > 9;
+}
+
+/**
+ * Parses the data of given record in the failed_jobs DB table.
+ *
+ * @param object $failedJob
+ * @return array
+ */
+function parse_failed_job($failedJob)
+{
+    $json = json_decode($failedJob->payload);
+    $command = unserialize($json->data->command);
+
+    return [
+        'id' => $failedJob->id,
+        'failedAt' => $failedJob->failed_at,
+        'commandName' => $json->data->commandName,
+        'errorMessage' => Str::limit($failedJob->exception, 255),
+        'parameters' => method_exists($command, 'getParameters') ? $command->getParameters() : [],
+    ];
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -78,9 +78,10 @@ function parse_failed_job($failedJob)
 
     return [
         'id' => $failedJob->id,
-        'failedAt' => $failedJob->failed_at,
-        'commandName' => $json->data->commandName,
-        'errorMessage' => Str::limit($failedJob->exception, 255),
+        'failed_at' => $failedJob->failed_at,
+        'command_name' => $json->data->commandName,
+        'error_message' => Str::limit($failedJob->exception, 255),
+        'exception' => $failedJob->exception,
         'parameters' => method_exists($command, 'getParameters') ? $command->getParameters() : [],
     ];
 }

--- a/resources/views/pages/exports/create.blade.php
+++ b/resources/views/pages/exports/create.blade.php
@@ -15,7 +15,7 @@
         {{ csrf_field()}}
 
         <div class="form-check">
-            <input class="form-check-input" name="topic" type="radio" value="MutePromotions" checked>
+            <input class="form-check-input" name="type" type="radio" value="MutePromotions" checked>
 
             <label class="form-check-label" for="MutePromotions">Failed jobs - Mute Promotions</label>
         </div>

--- a/resources/views/pages/exports/create.blade.php
+++ b/resources/views/pages/exports/create.blade.php
@@ -13,6 +13,7 @@
 
     <form method="POST" action="{{ route('exports.store') }}">
         {{ csrf_field()}}
+
         <div class="form-check">
             <input class="form-check-input" name="topic" type="radio" value="MutePromotions" checked>
 

--- a/resources/views/pages/exports/create.blade.php
+++ b/resources/views/pages/exports/create.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.master')
+
+@section('title', 'Export')
+
+@section('main_content')
+
+<div>
+    <h1>Create Export</h1>
+
+    <p>
+        Use this form to download Chompy data.
+    <p>
+
+    <form method="POST" action="{{ route('exports.store') }}">
+        {{ csrf_field()}}
+        <div class="form-check">
+            <input class="form-check-input" name="topic" type="radio" value="MutePromotions" checked>
+
+            <label class="form-check-label" for="MutePromotions">Failed jobs - Mute Promotions</label>
+        </div>
+
+        <div>
+            <input type="submit" class="btn btn-primary btn-lg" value="Download">
+        </div>
+    </form>
+</div>
+
+@stop

--- a/resources/views/pages/failed-jobs/index.blade.php
+++ b/resources/views/pages/failed-jobs/index.blade.php
@@ -5,39 +5,39 @@
 @section('main_content')
 
 <div>
-    {{$data->links()}}
+  {{$data->links()}}
 
-    <table class="table">
+  <table class="table">
 
     @foreach($data as $key => $row)
-        @php ($failedJob = parse_failed_job($row))
+      @php ($failedJob = parse_failed_job($row))
 
-        <tr class="row">
-            <td class="col-md-2">
-                <a href="/failed-jobs/{{$failedJob['id']}}">
-                  {{$failedJob['failed_at']}}
-                </a>
-            </td>
+      <tr class="row">
+        <td class="col-md-2">
+          <a href="/failed-jobs/{{$failedJob['id']}}">
+            {{$failedJob['failed_at']}}
+          </a>
+        </td>
 
-            <td class="col-md-4">
-              <strong>{{$failedJob['command_name']}}</strong>
+        <td class="col-md-4">
+          <strong>{{$failedJob['command_name']}}</strong>
 
-              <ul>
-                  @foreach ($failedJob['parameters'] as $key => $value)
-                      <li><code>{{$key}}</code> {{is_array($value) ? print_r($value, true) : $value}}</li>
-                  @endforeach
-              </ul>
-            </td>
+          <ul>
+              @foreach ($failedJob['parameters'] as $key => $value)
+                  <li><code>{{$key}}</code> {{is_array($value) ? print_r($value, true) : $value}}</li>
+              @endforeach
+          </ul>
+        </td>
 
-            <td class="col-md-6">
-              {{$failedJob['error_message']}}
-            </td>    
-        </tr>
+        <td class="col-md-6">
+          {{$failedJob['error_message']}}
+        </td>    
+      </tr>
     @endforeach
 
-    </table>
+  </table>
 
-    {{$data->links()}}
+  {{$data->links()}}
 </div>
 
 @stop

--- a/resources/views/pages/failed-jobs/index.blade.php
+++ b/resources/views/pages/failed-jobs/index.blade.php
@@ -5,30 +5,39 @@
 @section('main_content')
 
 <div>
-  {{$data->links()}}
+    {{$data->links()}}
+
     <table class="table">
+
     @foreach($data as $key => $row)
+        @php ($failedJob = parse_failed_job($row))
+
         <tr class="row">
-          <td class="col-md-2">
-            <a href="/failed-jobs/{{$row->id}}">{{$row->failed_at}}</a>
-          </td>
-          <td class="col-md-4">
-            <strong>{{$row->commandName}}</strong>
-            @isset($row->parameters)
+            <td class="col-md-2">
+                <a href="/failed-jobs/{{$failedJob['id']}}">
+                  {{$failedJob['failed_at']}}
+                </a>
+            </td>
+
+            <td class="col-md-4">
+              <strong>{{$failedJob['command_name']}}</strong>
+
               <ul>
-                @foreach ($row->parameters as $key => $value)
-                  <li><code>{{$key}}</code> {{is_array($value) ? print_r($value, true) : $value}}</li>
-                @endforeach
+                  @foreach ($failedJob['parameters'] as $key => $value)
+                      <li><code>{{$key}}</code> {{is_array($value) ? print_r($value, true) : $value}}</li>
+                  @endforeach
               </ul>
-            @endif
-          </td>
-          <td class="col-md-6">
-            {{$row->errorMessage}}
-          </td>    
+            </td>
+
+            <td class="col-md-6">
+              {{$failedJob['error_message']}}
+            </td>    
         </tr>
     @endforeach
+
     </table>
-  {{$data->links()}}
+
+    {{$data->links()}}
 </div>
 
 @stop

--- a/resources/views/pages/failed-jobs/show.blade.php
+++ b/resources/views/pages/failed-jobs/show.blade.php
@@ -13,18 +13,18 @@
     <div class="form-group row">
       <label class="col-sm-3 col-form-label">Failed at</label>
 
-      <div class="col-sm-9">{{$data['failed_at']}}</div>
+      <div class="col-sm-9">{{$failedJob['failed_at']}}</div>
     </div>
 
     <div class="form-group row">
       <label class="col-sm-3 col-form-label">Command</label>
 
       <div class="col-sm-9">
-        <strong>{{$data['command_name']}}</strong>
+        <strong>{{$failedJob['command_name']}}</strong>
 
-        @isset($data['parameters'])
+        @isset($failedJob['parameters'])
           <code>
-            {{json_encode($data['parameters'], TRUE)}}
+            {{json_encode($failedJob['parameters'], TRUE)}}
           </code>
         @endif
       </div>
@@ -33,7 +33,7 @@
     <div class="form-group row">
       <label class="col-sm-3 col-form-label">Exception</label>
 
-      <div class="col-sm-9">{{$data['exception']}}</div>
+      <div class="col-sm-9">{{$failedJob['exception']}}</div>
     </div>
 
      <div class="form-group row">

--- a/resources/views/pages/failed-jobs/show.blade.php
+++ b/resources/views/pages/failed-jobs/show.blade.php
@@ -7,26 +7,35 @@
 <div>
   <form action={{ url()->current() }} method="post">
     {{csrf_field()}}
+
     @method('delete')
+
     <div class="form-group row">
       <label class="col-sm-3 col-form-label">Failed at</label>
-      <div class="col-sm-9">{{$data->failed_at}}</div>
+
+      <div class="col-sm-9">{{$data['failed_at']}}</div>
     </div>
+
     <div class="form-group row">
       <label class="col-sm-3 col-form-label">Command</label>
+
       <div class="col-sm-9">
-        <strong>{{$data->commandName}}</strong>
-        @isset($data->parameters)
+        <strong>{{$data['command_name']}}</strong>
+
+        @isset($data['parameters'])
           <code>
-            {{json_encode($data->parameters, TRUE)}}
+            {{json_encode($data['parameters'], TRUE)}}
           </code>
         @endif
       </div>
     </div>
+
     <div class="form-group row">
       <label class="col-sm-3 col-form-label">Exception</label>
-      <div class="col-sm-9">{{$data->exception}}</div>
+
+      <div class="col-sm-9">{{$data['exception']}}</div>
     </div>
+
      <div class="form-group row">
         <div class="col-sm-9 col-sm-offset-3">
           <input type="submit" class="btn btn-danger" value="Delete" onclick="return confirm('Are you sure you want to delete this job? This cannot be undone.')">

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,10 @@ Route::resource('rock-the-vote-reports', 'RockTheVoteReportController', [
     'except' => ['delete'],
 ]);
 
+Route::resource('exports', 'ExportController', [
+    'only' => ['create', 'store'],
+]);
+
 Route::resource('users', 'UserController', ['only' => ['show']]);
 
 Route::get('/', function () {


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new web route, `/exports/create`, which will create a CSV containing all user ID's failed `ImportMutePromotions` jobs. This can eventually be built out to support downloading other failed job types as well-- but for now the immediate need is to find all ID's that failed in our mass-deletion of Customer.io profiles last month.

<img width="400"  src="https://user-images.githubusercontent.com/1236811/110957145-322d4b80-8300-11eb-9c40-83e1580b8f86.png">


### How should this be reviewed?

👀 

### Any background context you want to provide?

This PR also adds a new `parse_failed_job` helper to DRY decoding the data buried in the `payload` field of the `failed_jobs` DB table.

### Relevant tickets

References [Pivotal #177170418](https://www.pivotaltracker.com/story/show/177170418).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
