### PR TITLE
Add more verbose debug logs to partner endpoints.

### DIFF
--- a/app/Http/Controllers/ThirdParty/CallPowerController.php
+++ b/app/Http/Controllers/ThirdParty/CallPowerController.php
@@ -37,12 +37,7 @@ class CallPowerController extends Controller
             'number_dialed_into' => 'required',
         ]);
 
-        Log::debug('sending job to create post with details: ' . json_encode([
-            'mobile' => $request['mobile'],
-            'callpower_campaign_id' => $request['callpower_campaign_id'],
-            'status' => $request['status'],
-        ])
-        );
+        Log::debug('CallPowerController@store:' . json_encode($parameters));
 
         // Send to queued job.
         ImportCallPowerRecord::dispatch($parameters);

--- a/app/Http/Controllers/ThirdParty/CallPowerController.php
+++ b/app/Http/Controllers/ThirdParty/CallPowerController.php
@@ -37,7 +37,7 @@ class CallPowerController extends Controller
             'number_dialed_into' => 'required',
         ]);
 
-        Log::debug('CallPowerController@store:' . json_encode($parameters));
+        Log::debug('CallPowerController@store: ' . json_encode($parameters));
 
         // Send to queued job.
         ImportCallPowerRecord::dispatch($parameters);

--- a/app/Http/Controllers/ThirdParty/SoftEdgeController.php
+++ b/app/Http/Controllers/ThirdParty/SoftEdgeController.php
@@ -33,7 +33,7 @@ class SoftEdgeController extends Controller
             'campaign_target_district' => 'nullable|string',
         ]);
 
-        Log::debug('SoftEdgeController@store:' . json_encode($parameters));
+        Log::debug('SoftEdgeController@store: ' . json_encode($parameters));
 
         // Send to queued job.
         ImportSoftEdgeRecord::dispatch($parameters);

--- a/app/Http/Controllers/ThirdParty/SoftEdgeController.php
+++ b/app/Http/Controllers/ThirdParty/SoftEdgeController.php
@@ -33,10 +33,7 @@ class SoftEdgeController extends Controller
             'campaign_target_district' => 'nullable|string',
         ]);
 
-        Log::debug('sending job to create post with details', [
-            'northstar_id' => $request['northstar_id'],
-            'action_id' => $request['action_id'],
-        ]);
+        Log::debug('SoftEdgeController@store:' . json_encode($parameters));
 
         // Send to queued job.
         ImportSoftEdgeRecord::dispatch($parameters);

--- a/config/logging.php
+++ b/config/logging.php
@@ -41,13 +41,13 @@ return [
         'single' => [
             'driver' => 'single',
             'path' => storage_path('logs/laravel.log'),
-            'level' => 'debug',
+            'level' => env('LOG_LEVEL', 'debug'),
         ],
 
         'daily' => [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
-            'level' => 'debug',
+            'level' => env('LOG_LEVEL', 'debug'),
             'days' => 7,
         ],
 
@@ -69,12 +69,12 @@ return [
 
         'syslog' => [
             'driver' => 'syslog',
-            'level' => 'debug',
+            'level' => env('LOG_LEVEL', 'debug'),
         ],
 
         'errorlog' => [
             'driver' => 'errorlog',
-            'level' => 'debug',
+            'level' => env('LOG_LEVEL', 'debug'),
         ],
     ],
 ];


### PR DESCRIPTION
### What's this PR do?

This pull request adds verbose debug logs to our CallPower & SoftEdge controllers, which we'll use to ensure that the new Northstar versions of these endpoints work identically (by "replaying" requests from production on QA and seeing that they make the same posts).

I also added support for using `LOG_LEVEL` to customize log verbosity (so we can avoid verbose debug logs outside of... y'know, debugging things)! This follows a fairly common convention & is actually something we set via [our standard Terraform config](https://github.com/DoSomething/infrastructure/blob/a24190942d58f3ec0f25c8a857b69bb9f0fe554e/components/heroku_app/main.tf#L89).

### How should this be reviewed?

👀 

### Any background context you want to provide?

References https://github.com/DoSomething/northstar/pull/1206#discussion_r632753694.

### Relevant tickets

References [Pivotal #177733275](https://www.pivotaltracker.com/story/show/177733275).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
